### PR TITLE
Add bin-name to roave-infection

### DIFF
--- a/.github/workflows/roave-infection.yml
+++ b/.github/workflows/roave-infection.yml
@@ -8,6 +8,11 @@ on:
         default: composer update --prefer-dist --no-interaction --no-progress --optimize-autoloader --ansi
         required: false
         type: string
+      bin-name:
+        description: Binary name
+        default: roave-infection-static-analysis-plugin
+        required: false
+        type: string
       extensions:
         description: List of extensions to PHP.
         default:


### PR DESCRIPTION
Use case - using infection directly without a plugin (see https://github.com/yiisoft/html/issues/202).