### PR TITLE
Add `verbose` option to `codecov` action into `phpunit` workflow

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -43,6 +43,7 @@ on:
         type: string
       codecovVerbose:
         description: Specify whether the Codecov output should be verbose.
+        default: false
         required: false
         type: boolean
     secrets:

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -43,7 +43,6 @@ on:
         type: string
       codecovVerbose:
         description: Specify whether the Codecov output should be verbose.
-        default: false
         required: false
         type: boolean
     secrets:

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -41,6 +41,11 @@ on:
         default: composer:v2
         required: false
         type: string
+      codecovVerbose:
+        description: Specify whether the Codecov output should be verbose.
+        default: false
+        required: false
+        type: boolean
     secrets:
       codecovToken:
         description: Codecov upload token
@@ -101,3 +106,4 @@ jobs:
         with:
           token: ${{ secrets.codecovToken }}
           files: ./coverage.xml
+          verbose: ${{ inputs.codecovVerbose }}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any
