### PR TITLE
Allow BC check to install dev dependencies

### DIFF
--- a/.github/workflows/bc.yml
+++ b/.github/workflows/bc.yml
@@ -12,6 +12,10 @@ on:
         description: Use binary installed with Composer and skip installing binary in the action.
         default: false
         type: boolean
+      install-development-dependencies:
+        description: Install development dependencies of the compared package.
+        default: false
+        type: boolean
       extensions:
         description: List of extensions to PHP.
         default: ''
@@ -78,4 +82,4 @@ jobs:
           packages: ${{ inputs.required-packages }}
 
       - name: Run roave/backward-compatibility-check.
-        run: vendor/bin/roave-backward-compatibility-check
+        run: vendor/bin/roave-backward-compatibility-check ${{ inputs.install-development-dependencies && '--install-development-dependencies' || '' }}

--- a/.github/workflows/bc.yml
+++ b/.github/workflows/bc.yml
@@ -82,4 +82,4 @@ jobs:
           packages: ${{ inputs.required-packages }}
 
       - name: Run roave/backward-compatibility-check.
-        run: vendor/bin/roave-backward-compatibility-check ${{ inputs.install-development-dependencies && '--install-development-dependencies' || '' }}
+        run: vendor/bin/roave-backward-compatibility-check${{ inputs['install-development-dependencies'] && ' --install-development-dependencies' || '' }}


### PR DESCRIPTION
Adds an optional `install-development-dependencies` input to the reusable BC workflow.\n\nWhen enabled, the workflow passes `--install-development-dependencies` to `roave/backward-compatibility-check`. This lets consumers compare packages whose released API references symbols from development dependencies, while keeping the current default behavior unchanged.\n\nNeeded by yiisoft/validator#797, where Roave otherwise reports skipped debug collector symbols from the compared release.