### PR TITLE
Remove BC dev dependency input

### DIFF
--- a/.github/workflows/bc.yml
+++ b/.github/workflows/bc.yml
@@ -12,10 +12,6 @@ on:
         description: Use binary installed with Composer and skip installing binary in the action.
         default: false
         type: boolean
-      install-development-dependencies:
-        description: Install development dependencies of the compared package.
-        default: false
-        type: boolean
       extensions:
         description: List of extensions to PHP.
         default: ''
@@ -82,4 +78,4 @@ jobs:
           packages: ${{ inputs.required-packages }}
 
       - name: Run roave/backward-compatibility-check.
-        run: vendor/bin/roave-backward-compatibility-check${{ inputs['install-development-dependencies'] && ' --install-development-dependencies' || '' }}
+        run: vendor/bin/roave-backward-compatibility-check


### PR DESCRIPTION
## Summary
- remove the install-development-dependencies input from the reusable BC workflow
- run roave/backward-compatibility-check without appending the removed flag

## Verification
- In yiisoft/validator, removed the caller input and verified vendor/bin/roave-backward-compatibility-check passes with a Roave baseline for the expected ignores.