### PR TITLE
Harden GitHub workflows

### DIFF
--- a/.github/workflows/bc.yml
+++ b/.github/workflows/bc.yml
@@ -51,12 +51,13 @@ jobs:
 
     steps:
       - name: Checkout.
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Install PHP with extensions.
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@b604ade2a87db23f8871b7182e69ec5e75effb45
         with:
           extensions: ${{ inputs.extensions }}
           ini-values: ${{ inputs.ini-values }}
@@ -65,7 +66,7 @@ jobs:
 
       - name: Install Composer dependencies
         if: inputs.usePackageBin == true
-        uses: ramsey/composer-install@v4
+        uses: ramsey/composer-install@26d8a556604053a9612623447203a691f406fbe6
 
       - name: Install roave/backward-compatibility-check
         if: inputs.usePackageBin == false
@@ -73,7 +74,7 @@ jobs:
 
       - if: ${{ inputs.required-packages != '' }}
         name: Install required packages.
-        uses: yiisoft/actions/install-packages@master
+        uses: yiisoft/actions/install-packages@ab62d6b3b0e0cff6c9724ec5a395bedb41c639a2
         with:
           packages: ${{ inputs.required-packages }}
 

--- a/.github/workflows/bc.yml
+++ b/.github/workflows/bc.yml
@@ -74,7 +74,7 @@ jobs:
 
       - if: ${{ inputs.required-packages != '' }}
         name: Install required packages.
-        uses: yiisoft/actions/install-packages@ab62d6b3b0e0cff6c9724ec5a395bedb41c639a2
+        uses: yiisoft/actions/install-packages@master
         with:
           packages: ${{ inputs.required-packages }}
 

--- a/.github/workflows/bc.yml
+++ b/.github/workflows/bc.yml
@@ -38,6 +38,9 @@ on:
         required: false
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   bc:
     name: PHP ${{ matrix.php }}-${{ matrix.os }}

--- a/.github/workflows/codeception.yml
+++ b/.github/workflows/codeception.yml
@@ -109,21 +109,37 @@ jobs:
         run: composer self-update
 
       - name: Install dependencies with composer.
-        run: $INPUTS_COMPOSER_COMMAND
+        if: runner.os != 'Windows'
+        run: |
+          printf '%s\n' "$INPUTS_COMPOSER_COMMAND" > "$RUNNER_TEMP/composer-command.sh"
+          bash -e "$RUNNER_TEMP/composer-command.sh"
+        env:
+          INPUTS_COMPOSER_COMMAND: ${{ inputs.composer-command }}
+
+      - name: Install dependencies with composer.
+        if: runner.os == 'Windows'
+        shell: powershell
+        run: |
+          Set-Content -Path "$env:RUNNER_TEMP\composer-command.ps1" -Value $env:INPUTS_COMPOSER_COMMAND
+          & "$env:RUNNER_TEMP\composer-command.ps1"
         env:
           INPUTS_COMPOSER_COMMAND: ${{ inputs.composer-command }}
 
       - name: Run tests with codeception with code coverage with shell bash.
         if: matrix.os == 'ubuntu-latest'
         continue-on-error:  ${{ inputs.debug }}
-        run: $INPUTS_CODECEPTION_COMMAND
+        run: |
+          printf '%s\n' "$INPUTS_CODECEPTION_COMMAND" > "$RUNNER_TEMP/codeception-command.sh"
+          bash -e "$RUNNER_TEMP/codeception-command.sh"
         env:
           INPUTS_CODECEPTION_COMMAND: ${{ inputs.codeception-command }}
 
       - name: Run tests with codeception with code coverage with shell powershell.
         if: matrix.os == 'windows-latest'
         continue-on-error:  ${{ inputs.debug }}
-        run: $env:INPUTS_CODECEPTION_COMMAND
+        run: |
+          Set-Content -Path "$env:RUNNER_TEMP\codeception-command.ps1" -Value $env:INPUTS_CODECEPTION_COMMAND
+          & "$env:RUNNER_TEMP\codeception-command.ps1"
         shell: powershell
         env:
           INPUTS_CODECEPTION_COMMAND: ${{ inputs.codeception-command }}

--- a/.github/workflows/codeception.yml
+++ b/.github/workflows/codeception.yml
@@ -59,6 +59,9 @@ on:
         description: Deprecated, use CODECOV_TOKEN
         required: false
 
+permissions:
+  contents: read
+
 jobs:
   codeception:
     name: PHP ${{ matrix.php }}-${{ matrix.os }}

--- a/.github/workflows/codeception.yml
+++ b/.github/workflows/codeception.yml
@@ -76,10 +76,12 @@ jobs:
 
     steps:
       - name: Checkout.
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
 
       - name: Install PHP with extensions.
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@b604ade2a87db23f8871b7182e69ec5e75effb45
         with:
           coverage: ${{ inputs.coverage }}
           extensions: ${{ inputs.extensions }}
@@ -96,7 +98,7 @@ jobs:
         run: echo "COMPOSER_CACHE_DIR=~\AppData\Local\Composer" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
       - name: Cache dependencies installed with composer.
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
         with:
           path: ${{ env.COMPOSER_CACHE_DIR }}
           key: php${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}
@@ -107,22 +109,28 @@ jobs:
         run: composer self-update
 
       - name: Install dependencies with composer.
-        run: ${{ inputs.composer-command }}
+        run: $INPUTS_COMPOSER_COMMAND
+        env:
+          INPUTS_COMPOSER_COMMAND: ${{ inputs.composer-command }}
 
       - name: Run tests with codeception with code coverage with shell bash.
         if: matrix.os == 'ubuntu-latest'
         continue-on-error:  ${{ inputs.debug }}
-        run: ${{ inputs.codeception-command }}
+        run: $INPUTS_CODECEPTION_COMMAND
+        env:
+          INPUTS_CODECEPTION_COMMAND: ${{ inputs.codeception-command }}
 
       - name: Run tests with codeception with code coverage with shell powershell.
         if: matrix.os == 'windows-latest'
         continue-on-error:  ${{ inputs.debug }}
-        run: ${{ inputs.codeception-command }}
+        run: $env:INPUTS_CODECEPTION_COMMAND
         shell: powershell
+        env:
+          INPUTS_CODECEPTION_COMMAND: ${{ inputs.codeception-command }}
 
       - name: Upload coverage to Codecov.
         if: matrix.os == 'ubuntu-latest' && matrix.php == '8.1' && inputs.debug == false
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238
         with:
           token: ${{ secrets.CODECOV_TOKEN || secrets.codecovToken }}
           files: tests/_output/coverage.xml
@@ -130,11 +138,11 @@ jobs:
 
       - name: Archive codeception results.
         if: ${{ inputs.debug }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: output
           path: ./runtime/tests/_output
 
       - name: Download all workflow run artifacts.
         if: ${{ inputs.debug }}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093

--- a/.github/workflows/composer-require-checker.yml
+++ b/.github/workflows/composer-require-checker.yml
@@ -77,7 +77,7 @@ jobs:
 
       - if: ${{ inputs.required-packages != '' }}
         name: Install required packages.
-        uses: yiisoft/actions/install-packages@ab62d6b3b0e0cff6c9724ec5a395bedb41c639a2
+        uses: yiisoft/actions/install-packages@master
         with:
           packages: ${{ inputs.required-packages }}
 

--- a/.github/workflows/composer-require-checker.yml
+++ b/.github/workflows/composer-require-checker.yml
@@ -34,6 +34,9 @@ on:
         required: false
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   composer-require-checker:
     name: PHP ${{ matrix.php }}-${{ matrix.os }}

--- a/.github/workflows/composer-require-checker.yml
+++ b/.github/workflows/composer-require-checker.yml
@@ -71,7 +71,19 @@ jobs:
             php${{ matrix.php }}-composer-
 
       - name: Install dependencies with composer.
-        run: $INPUTS_COMPOSER_COMMAND
+        if: runner.os != 'Windows'
+        run: |
+          printf '%s\n' "$INPUTS_COMPOSER_COMMAND" > "$RUNNER_TEMP/composer-command.sh"
+          bash -e "$RUNNER_TEMP/composer-command.sh"
+        env:
+          INPUTS_COMPOSER_COMMAND: ${{ inputs.composer-command }}
+
+      - name: Install dependencies with composer.
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          Set-Content -Path "$env:RUNNER_TEMP\composer-command.ps1" -Value $env:INPUTS_COMPOSER_COMMAND
+          & "$env:RUNNER_TEMP\composer-command.ps1"
         env:
           INPUTS_COMPOSER_COMMAND: ${{ inputs.composer-command }}
 

--- a/.github/workflows/composer-require-checker.yml
+++ b/.github/workflows/composer-require-checker.yml
@@ -47,10 +47,12 @@ jobs:
 
     steps:
       - name: Checkout.
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          persist-credentials: false
 
       - name: Install PHP with extensions.
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@b604ade2a87db23f8871b7182e69ec5e75effb45
         with:
           php-version: ${{ matrix.php }}
           extensions: ${{ inputs.extensions }}
@@ -61,7 +63,7 @@ jobs:
         run: echo "COMPOSER_CACHE_DIR=$(composer config cache-dir)" >> $GITHUB_ENV
 
       - name: Cache dependencies installed with composer.
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
         with:
           path: ${{ env.COMPOSER_CACHE_DIR }}
           key: php${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}
@@ -69,13 +71,17 @@ jobs:
             php${{ matrix.php }}-composer-
 
       - name: Install dependencies with composer.
-        run: ${{ inputs.composer-command }}
+        run: $INPUTS_COMPOSER_COMMAND
+        env:
+          INPUTS_COMPOSER_COMMAND: ${{ inputs.composer-command }}
 
       - if: ${{ inputs.required-packages != '' }}
         name: Install required packages.
-        uses: yiisoft/actions/install-packages@master
+        uses: yiisoft/actions/install-packages@ab62d6b3b0e0cff6c9724ec5a395bedb41c639a2
         with:
           packages: ${{ inputs.required-packages }}
 
       - name: Check dependencies.
-        run: args=(); test -n "${{ inputs.config }}" && args+=("--config-file=${{ inputs.config }}"); composer-require-checker ${args[@]}
+        run: args=(); test -n "$INPUTS_CONFIG" && args+=("--config-file=$INPUTS_CONFIG"); composer-require-checker "${args[@]}"
+        env:
+          INPUTS_CONFIG: ${{ inputs.config }}

--- a/.github/workflows/db-mariadb.yml
+++ b/.github/workflows/db-mariadb.yml
@@ -50,10 +50,12 @@ jobs:
 
     steps:
       - name: Checkout.
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          persist-credentials: false
 
       - name: Install PHP with extensions.
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@b604ade2a87db23f8871b7182e69ec5e75effb45
         with:
           php-version: ${{ matrix.php }}
           extensions: ${{ env.extensions }}
@@ -62,13 +64,13 @@ jobs:
 
       - name: Install Composer dependencies + required yiisoft/db-mysql
         if: ${{ (github.event.pull_request.base.repo.name || github.event.repository.name) != 'db-mysql' }}
-        uses: yiisoft/actions/install-packages/install-package@master
+        uses: yiisoft/actions/install-packages/install-package@ab62d6b3b0e0cff6c9724ec5a395bedb41c639a2
         with:
           package: db-mysql
 
       - name: Install yiisoft/db package.
         if: ${{ (github.event.pull_request.base.repo.name || github.event.repository.name) != 'db' }}
-        uses: yiisoft/actions/install-packages/install-package@master
+        uses: yiisoft/actions/install-packages/install-package@ab62d6b3b0e0cff6c9724ec5a395bedb41c639a2
         with:
           package: db
 
@@ -77,7 +79,7 @@ jobs:
 
       - name: Upload coverage to Codecov.
         if: ${{ matrix.php == inputs.codecov-php }}
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@04b047e8bb82a0c002c8312c1c880fbc6a999d45
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml

--- a/.github/workflows/db-mariadb.yml
+++ b/.github/workflows/db-mariadb.yml
@@ -23,6 +23,9 @@ on:
         description: Codecov upload token
         required: false
 
+permissions:
+  contents: read
+
 jobs:
   tests:
     name: PHP ${{ matrix.php }}

--- a/.github/workflows/db-mariadb.yml
+++ b/.github/workflows/db-mariadb.yml
@@ -64,13 +64,13 @@ jobs:
 
       - name: Install Composer dependencies + required yiisoft/db-mysql
         if: ${{ (github.event.pull_request.base.repo.name || github.event.repository.name) != 'db-mysql' }}
-        uses: yiisoft/actions/install-packages/install-package@ab62d6b3b0e0cff6c9724ec5a395bedb41c639a2
+        uses: yiisoft/actions/install-packages/install-package@master
         with:
           package: db-mysql
 
       - name: Install yiisoft/db package.
         if: ${{ (github.event.pull_request.base.repo.name || github.event.repository.name) != 'db' }}
-        uses: yiisoft/actions/install-packages/install-package@ab62d6b3b0e0cff6c9724ec5a395bedb41c639a2
+        uses: yiisoft/actions/install-packages/install-package@master
         with:
           package: db
 

--- a/.github/workflows/db-mssql-2017.yml
+++ b/.github/workflows/db-mssql-2017.yml
@@ -26,10 +26,12 @@ jobs:
         run: sqlcmd -S localhost -U SA -P 'YourStrong!Passw0rd' -Q 'CREATE DATABASE yiitest'
 
       - name: Checkout.
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          persist-credentials: false
 
       - name: Install PHP with extensions.
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@b604ade2a87db23f8871b7182e69ec5e75effb45
         with:
           php-version: ${{ inputs.php }}
           extensions: ${{ env.extensions }}
@@ -37,13 +39,13 @@ jobs:
 
       - name: Install Composer dependencies + required yiisoft/db-mssql
         if: ${{ (github.event.pull_request.base.repo.name || github.event.repository.name) != 'db-mssql' }}
-        uses: yiisoft/actions/install-packages/install-package@master
+        uses: yiisoft/actions/install-packages/install-package@ab62d6b3b0e0cff6c9724ec5a395bedb41c639a2
         with:
           package: db-mssql
 
       - name: Install yiisoft/db package.
         if: ${{ (github.event.pull_request.base.repo.name || github.event.repository.name) != 'db' }}
-        uses: yiisoft/actions/install-packages/install-package@master
+        uses: yiisoft/actions/install-packages/install-package@ab62d6b3b0e0cff6c9724ec5a395bedb41c639a2
         with:
           package: db
 

--- a/.github/workflows/db-mssql-2017.yml
+++ b/.github/workflows/db-mssql-2017.yml
@@ -39,13 +39,13 @@ jobs:
 
       - name: Install Composer dependencies + required yiisoft/db-mssql
         if: ${{ (github.event.pull_request.base.repo.name || github.event.repository.name) != 'db-mssql' }}
-        uses: yiisoft/actions/install-packages/install-package@ab62d6b3b0e0cff6c9724ec5a395bedb41c639a2
+        uses: yiisoft/actions/install-packages/install-package@master
         with:
           package: db-mssql
 
       - name: Install yiisoft/db package.
         if: ${{ (github.event.pull_request.base.repo.name || github.event.repository.name) != 'db' }}
-        uses: yiisoft/actions/install-packages/install-package@ab62d6b3b0e0cff6c9724ec5a395bedb41c639a2
+        uses: yiisoft/actions/install-packages/install-package@master
         with:
           package: db
 

--- a/.github/workflows/db-mssql-2017.yml
+++ b/.github/workflows/db-mssql-2017.yml
@@ -9,6 +9,9 @@ on:
         required: false
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   tests:
     name: PHP ${{ inputs.php }}

--- a/.github/workflows/db-mssql.yml
+++ b/.github/workflows/db-mssql.yml
@@ -59,10 +59,12 @@ jobs:
         run: docker exec -i mssql /opt/mssql-tools18/bin/sqlcmd -C -S localhost -U SA -P 'YourStrong!Passw0rd' -Q 'CREATE DATABASE yiitest'
 
       - name: Checkout.
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          persist-credentials: false
 
       - name: Install PHP with extensions.
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@b604ade2a87db23f8871b7182e69ec5e75effb45
         with:
           php-version: ${{ matrix.php }}
           extensions: ${{ env.extensions }}
@@ -71,13 +73,13 @@ jobs:
 
       - name: Install Composer dependencies + required yiisoft/db-mssql
         if: ${{ (github.event.pull_request.base.repo.name || github.event.repository.name) != 'db-mssql' }}
-        uses: yiisoft/actions/install-packages/install-package@master
+        uses: yiisoft/actions/install-packages/install-package@ab62d6b3b0e0cff6c9724ec5a395bedb41c639a2
         with:
           package: db-mssql
 
       - name: Install yiisoft/db package.
         if: ${{ (github.event.pull_request.base.repo.name || github.event.repository.name) != 'db' }}
-        uses: yiisoft/actions/install-packages/install-package@master
+        uses: yiisoft/actions/install-packages/install-package@ab62d6b3b0e0cff6c9724ec5a395bedb41c639a2
         with:
           package: db
 
@@ -86,7 +88,7 @@ jobs:
 
       - name: Upload coverage to Codecov.
         if: ${{ matrix.php == inputs.codecov-php }}
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@04b047e8bb82a0c002c8312c1c880fbc6a999d45
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml

--- a/.github/workflows/db-mssql.yml
+++ b/.github/workflows/db-mssql.yml
@@ -23,6 +23,9 @@ on:
         description: Codecov upload token
         required: false
 
+permissions:
+  contents: read
+
 jobs:
   tests:
     name: PHP ${{ matrix.php }}

--- a/.github/workflows/db-mssql.yml
+++ b/.github/workflows/db-mssql.yml
@@ -73,13 +73,13 @@ jobs:
 
       - name: Install Composer dependencies + required yiisoft/db-mssql
         if: ${{ (github.event.pull_request.base.repo.name || github.event.repository.name) != 'db-mssql' }}
-        uses: yiisoft/actions/install-packages/install-package@ab62d6b3b0e0cff6c9724ec5a395bedb41c639a2
+        uses: yiisoft/actions/install-packages/install-package@master
         with:
           package: db-mssql
 
       - name: Install yiisoft/db package.
         if: ${{ (github.event.pull_request.base.repo.name || github.event.repository.name) != 'db' }}
-        uses: yiisoft/actions/install-packages/install-package@ab62d6b3b0e0cff6c9724ec5a395bedb41c639a2
+        uses: yiisoft/actions/install-packages/install-package@master
         with:
           package: db
 

--- a/.github/workflows/db-mutation.yml
+++ b/.github/workflows/db-mutation.yml
@@ -51,13 +51,13 @@ jobs:
 
       - name: Install Composer dependencies + required yiisoft/db-pgsql package.
         if: ${{ (github.event.pull_request.base.repo.name || github.event.repository.name) != 'db-pgsql' }}
-        uses: yiisoft/actions/install-packages/install-package@ab62d6b3b0e0cff6c9724ec5a395bedb41c639a2
+        uses: yiisoft/actions/install-packages/install-package@master
         with:
           package: db-pgsql
 
       - name: Install yiisoft/db package.
         if: ${{ (github.event.pull_request.base.repo.name || github.event.repository.name) != 'db' }}
-        uses: yiisoft/actions/install-packages/install-package@ab62d6b3b0e0cff6c9724ec5a395bedb41c639a2
+        uses: yiisoft/actions/install-packages/install-package@master
         with:
           package: db
 

--- a/.github/workflows/db-mutation.yml
+++ b/.github/workflows/db-mutation.yml
@@ -14,6 +14,9 @@ on:
         required: false
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   tests:
     name: PHP ${{ inputs.php }}

--- a/.github/workflows/db-mutation.yml
+++ b/.github/workflows/db-mutation.yml
@@ -36,10 +36,12 @@ jobs:
 
     steps:
       - name: Checkout.
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          persist-credentials: false
 
       - name: Install PHP with extensions.
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@b604ade2a87db23f8871b7182e69ec5e75effb45
         with:
           php-version: ${{ inputs.php }}
           extensions: ${{ env.extensions }}
@@ -49,13 +51,13 @@ jobs:
 
       - name: Install Composer dependencies + required yiisoft/db-pgsql package.
         if: ${{ (github.event.pull_request.base.repo.name || github.event.repository.name) != 'db-pgsql' }}
-        uses: yiisoft/actions/install-packages/install-package@master
+        uses: yiisoft/actions/install-packages/install-package@ab62d6b3b0e0cff6c9724ec5a395bedb41c639a2
         with:
           package: db-pgsql
 
       - name: Install yiisoft/db package.
         if: ${{ (github.event.pull_request.base.repo.name || github.event.repository.name) != 'db' }}
-        uses: yiisoft/actions/install-packages/install-package@master
+        uses: yiisoft/actions/install-packages/install-package@ab62d6b3b0e0cff6c9724ec5a395bedb41c639a2
         with:
           package: db
 

--- a/.github/workflows/db-mysql.yml
+++ b/.github/workflows/db-mysql.yml
@@ -23,6 +23,9 @@ on:
         description: Codecov upload token
         required: false
 
+permissions:
+  contents: read
+
 jobs:
   tests:
     name: PHP ${{ matrix.php }}

--- a/.github/workflows/db-mysql.yml
+++ b/.github/workflows/db-mysql.yml
@@ -63,13 +63,13 @@ jobs:
 
       - name: Install Composer dependencies + required yiisoft/db-mysql
         if: ${{ (github.event.pull_request.base.repo.name || github.event.repository.name) != 'db-mysql' }}
-        uses: yiisoft/actions/install-packages/install-package@ab62d6b3b0e0cff6c9724ec5a395bedb41c639a2
+        uses: yiisoft/actions/install-packages/install-package@master
         with:
           package: db-mysql
 
       - name: Install yiisoft/db package.
         if: ${{ (github.event.pull_request.base.repo.name || github.event.repository.name) != 'db' }}
-        uses: yiisoft/actions/install-packages/install-package@ab62d6b3b0e0cff6c9724ec5a395bedb41c639a2
+        uses: yiisoft/actions/install-packages/install-package@master
         with:
           package: db
 

--- a/.github/workflows/db-mysql.yml
+++ b/.github/workflows/db-mysql.yml
@@ -49,10 +49,12 @@ jobs:
 
     steps:
       - name: Checkout.
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          persist-credentials: false
 
       - name: Install PHP with extensions.
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@b604ade2a87db23f8871b7182e69ec5e75effb45
         with:
           php-version: ${{ matrix.php }}
           extensions: ${{ env.extensions }}
@@ -61,13 +63,13 @@ jobs:
 
       - name: Install Composer dependencies + required yiisoft/db-mysql
         if: ${{ (github.event.pull_request.base.repo.name || github.event.repository.name) != 'db-mysql' }}
-        uses: yiisoft/actions/install-packages/install-package@master
+        uses: yiisoft/actions/install-packages/install-package@ab62d6b3b0e0cff6c9724ec5a395bedb41c639a2
         with:
           package: db-mysql
 
       - name: Install yiisoft/db package.
         if: ${{ (github.event.pull_request.base.repo.name || github.event.repository.name) != 'db' }}
-        uses: yiisoft/actions/install-packages/install-package@master
+        uses: yiisoft/actions/install-packages/install-package@ab62d6b3b0e0cff6c9724ec5a395bedb41c639a2
         with:
           package: db
 
@@ -76,7 +78,7 @@ jobs:
 
       - name: Upload coverage to Codecov.
         if: ${{ matrix.php == inputs.codecov-php }}
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@04b047e8bb82a0c002c8312c1c880fbc6a999d45
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml

--- a/.github/workflows/db-oracle.yml
+++ b/.github/workflows/db-oracle.yml
@@ -56,10 +56,12 @@ jobs:
         run: docker exec -i oci bash -c "sqlplus -s system/root@XE <<< 'ALTER USER system DEFAULT TABLESPACE USERS;'"
 
       - name: Checkout.
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          persist-credentials: false
 
       - name: Install PHP with extensions.
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@b604ade2a87db23f8871b7182e69ec5e75effb45
         with:
           php-version: ${{ matrix.php }}
           extensions: ${{ env.extensions }}
@@ -68,13 +70,13 @@ jobs:
 
       - name: Install Composer dependencies + required yiisoft/db-oracle
         if: ${{ (github.event.pull_request.base.repo.name || github.event.repository.name) != 'db-oracle' }}
-        uses: yiisoft/actions/install-packages/install-package@master
+        uses: yiisoft/actions/install-packages/install-package@ab62d6b3b0e0cff6c9724ec5a395bedb41c639a2
         with:
           package: db-oracle
 
       - name: Install yiisoft/db package.
         if: ${{ (github.event.pull_request.base.repo.name || github.event.repository.name) != 'db' }}
-        uses: yiisoft/actions/install-packages/install-package@master
+        uses: yiisoft/actions/install-packages/install-package@ab62d6b3b0e0cff6c9724ec5a395bedb41c639a2
         with:
           package: db
 
@@ -83,7 +85,7 @@ jobs:
 
       - name: Upload coverage to Codecov.
         if: ${{ matrix.php == inputs.codecov-php }}
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@04b047e8bb82a0c002c8312c1c880fbc6a999d45
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml

--- a/.github/workflows/db-oracle.yml
+++ b/.github/workflows/db-oracle.yml
@@ -70,13 +70,13 @@ jobs:
 
       - name: Install Composer dependencies + required yiisoft/db-oracle
         if: ${{ (github.event.pull_request.base.repo.name || github.event.repository.name) != 'db-oracle' }}
-        uses: yiisoft/actions/install-packages/install-package@ab62d6b3b0e0cff6c9724ec5a395bedb41c639a2
+        uses: yiisoft/actions/install-packages/install-package@master
         with:
           package: db-oracle
 
       - name: Install yiisoft/db package.
         if: ${{ (github.event.pull_request.base.repo.name || github.event.repository.name) != 'db' }}
-        uses: yiisoft/actions/install-packages/install-package@ab62d6b3b0e0cff6c9724ec5a395bedb41c639a2
+        uses: yiisoft/actions/install-packages/install-package@master
         with:
           package: db
 

--- a/.github/workflows/db-oracle.yml
+++ b/.github/workflows/db-oracle.yml
@@ -23,6 +23,9 @@ on:
         description: Codecov upload token
         required: false
 
+permissions:
+  contents: read
+
 jobs:
   tests:
     name: PHP ${{ matrix.php }}

--- a/.github/workflows/db-pgsql.yml
+++ b/.github/workflows/db-pgsql.yml
@@ -49,10 +49,12 @@ jobs:
 
     steps:
       - name: Checkout.
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          persist-credentials: false
 
       - name: Install PHP with extensions.
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@b604ade2a87db23f8871b7182e69ec5e75effb45
         with:
           php-version: ${{ matrix.php }}
           extensions: ${{ env.extensions }}
@@ -61,13 +63,13 @@ jobs:
 
       - name: Install Composer dependencies + required yiisoft/db-pgsql
         if: ${{ (github.event.pull_request.base.repo.name || github.event.repository.name) != 'db-pgsql' }}
-        uses: yiisoft/actions/install-packages/install-package@master
+        uses: yiisoft/actions/install-packages/install-package@ab62d6b3b0e0cff6c9724ec5a395bedb41c639a2
         with:
           package: db-pgsql
 
       - name: Install yiisoft/db package.
         if: ${{ (github.event.pull_request.base.repo.name || github.event.repository.name) != 'db' }}
-        uses: yiisoft/actions/install-packages/install-package@master
+        uses: yiisoft/actions/install-packages/install-package@ab62d6b3b0e0cff6c9724ec5a395bedb41c639a2
         with:
           package: db
 
@@ -76,7 +78,7 @@ jobs:
 
       - name: Upload coverage to Codecov.
         if: ${{ matrix.php == inputs.codecov-php }}
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@04b047e8bb82a0c002c8312c1c880fbc6a999d45
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml

--- a/.github/workflows/db-pgsql.yml
+++ b/.github/workflows/db-pgsql.yml
@@ -23,6 +23,9 @@ on:
         description: Codecov upload token
         required: false
 
+permissions:
+  contents: read
+
 jobs:
   tests:
     name: PHP ${{ matrix.php }}

--- a/.github/workflows/db-pgsql.yml
+++ b/.github/workflows/db-pgsql.yml
@@ -63,13 +63,13 @@ jobs:
 
       - name: Install Composer dependencies + required yiisoft/db-pgsql
         if: ${{ (github.event.pull_request.base.repo.name || github.event.repository.name) != 'db-pgsql' }}
-        uses: yiisoft/actions/install-packages/install-package@ab62d6b3b0e0cff6c9724ec5a395bedb41c639a2
+        uses: yiisoft/actions/install-packages/install-package@master
         with:
           package: db-pgsql
 
       - name: Install yiisoft/db package.
         if: ${{ (github.event.pull_request.base.repo.name || github.event.repository.name) != 'db' }}
-        uses: yiisoft/actions/install-packages/install-package@ab62d6b3b0e0cff6c9724ec5a395bedb41c639a2
+        uses: yiisoft/actions/install-packages/install-package@master
         with:
           package: db
 

--- a/.github/workflows/db-sqlite.yml
+++ b/.github/workflows/db-sqlite.yml
@@ -50,13 +50,13 @@ jobs:
 
       - name: Install Composer dependencies + required yiisoft/db-sqlite
         if: ${{ (github.event.pull_request.base.repo.name || github.event.repository.name) != 'db-sqlite' }}
-        uses: yiisoft/actions/install-packages/install-package@ab62d6b3b0e0cff6c9724ec5a395bedb41c639a2
+        uses: yiisoft/actions/install-packages/install-package@master
         with:
           package: db-sqlite
 
       - name: Install yiisoft/db package.
         if: ${{ (github.event.pull_request.base.repo.name || github.event.repository.name) != 'db' }}
-        uses: yiisoft/actions/install-packages/install-package@ab62d6b3b0e0cff6c9724ec5a395bedb41c639a2
+        uses: yiisoft/actions/install-packages/install-package@master
         with:
           package: db
 

--- a/.github/workflows/db-sqlite.yml
+++ b/.github/workflows/db-sqlite.yml
@@ -18,6 +18,9 @@ on:
         description: Codecov upload token
         required: false
 
+permissions:
+  contents: read
+
 jobs:
   tests:
     name: PHP ${{ matrix.php }} ${{ matrix.os }}

--- a/.github/workflows/db-sqlite.yml
+++ b/.github/workflows/db-sqlite.yml
@@ -36,10 +36,12 @@ jobs:
 
     steps:
       - name: Checkout.
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          persist-credentials: false
 
       - name: Install PHP with extensions.
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@b604ade2a87db23f8871b7182e69ec5e75effb45
         with:
           php-version: ${{ matrix.php }}
           extensions: ${{ env.extensions }}
@@ -48,13 +50,13 @@ jobs:
 
       - name: Install Composer dependencies + required yiisoft/db-sqlite
         if: ${{ (github.event.pull_request.base.repo.name || github.event.repository.name) != 'db-sqlite' }}
-        uses: yiisoft/actions/install-packages/install-package@master
+        uses: yiisoft/actions/install-packages/install-package@ab62d6b3b0e0cff6c9724ec5a395bedb41c639a2
         with:
           package: db-sqlite
 
       - name: Install yiisoft/db package.
         if: ${{ (github.event.pull_request.base.repo.name || github.event.repository.name) != 'db' }}
-        uses: yiisoft/actions/install-packages/install-package@master
+        uses: yiisoft/actions/install-packages/install-package@ab62d6b3b0e0cff6c9724ec5a395bedb41c639a2
         with:
           package: db
 
@@ -63,7 +65,7 @@ jobs:
 
       - name: Upload coverage to Codecov.
         if: ${{ matrix.os == 'ubuntu-latest' && matrix.php == inputs.codecov-php }}
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@04b047e8bb82a0c002c8312c1c880fbc6a999d45
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml

--- a/.github/workflows/ecs.yml
+++ b/.github/workflows/ecs.yml
@@ -61,7 +61,19 @@ jobs:
         run: composer self-update
 
       - name: Install dependencies with composer.
-        run: $INPUTS_COMPOSER_COMMAND
+        if: runner.os != 'Windows'
+        run: |
+          printf '%s\n' "$INPUTS_COMPOSER_COMMAND" > "$RUNNER_TEMP/composer-command.sh"
+          bash -e "$RUNNER_TEMP/composer-command.sh"
+        env:
+          INPUTS_COMPOSER_COMMAND: ${{ inputs.composer-command }}
+
+      - name: Install dependencies with composer.
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          Set-Content -Path "$env:RUNNER_TEMP\composer-command.ps1" -Value $env:INPUTS_COMPOSER_COMMAND
+          & "$env:RUNNER_TEMP\composer-command.ps1"
         env:
           INPUTS_COMPOSER_COMMAND: ${{ inputs.composer-command }}
 

--- a/.github/workflows/ecs.yml
+++ b/.github/workflows/ecs.yml
@@ -45,10 +45,12 @@ jobs:
 
     steps:
       - name: Checkout.
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
 
       - name: Install PHP.
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@b604ade2a87db23f8871b7182e69ec5e75effb45
         with:
           coverage: none
           extensions: ${{ inputs.extensions}}
@@ -59,7 +61,9 @@ jobs:
         run: composer self-update
 
       - name: Install dependencies with composer.
-        run: ${{ inputs.composer-command }}
+        run: $INPUTS_COMPOSER_COMMAND
+        env:
+          INPUTS_COMPOSER_COMMAND: ${{ inputs.composer-command }}
 
       - name: Run easy-coding-standard.
         run: vendor/bin/ecs check src tests --ansi

--- a/.github/workflows/ecs.yml
+++ b/.github/workflows/ecs.yml
@@ -31,6 +31,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   ecs:
     name: PHP ${{ matrix.php }}-${{ matrix.os }}

--- a/.github/workflows/infection.yml
+++ b/.github/workflows/infection.yml
@@ -51,10 +51,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          persist-credentials: false
 
       - name: Install PHP with extensions
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@b604ade2a87db23f8871b7182e69ec5e75effb45
         with:
           coverage: xdebug
           extensions: ${{ inputs.extensions }}
@@ -62,16 +64,17 @@ jobs:
           php-version: ${{ matrix.php }}
 
       - name: Install Composer dependencies
-        uses: ramsey/composer-install@v4
+        uses: ramsey/composer-install@26d8a556604053a9612623447203a691f406fbe6
 
       - if: ${{ inputs.required-packages != '' }}
         name: Install required packages.
-        uses: yiisoft/actions/install-packages@master
+        uses: yiisoft/actions/install-packages@ab62d6b3b0e0cff6c9724ec5a395bedb41c639a2
         with:
           packages: ${{ inputs.required-packages }}
 
       - name: Run infection
         run: |
-          vendor/bin/infection ${{ inputs.infection-args }}
+          vendor/bin/infection $INPUTS_INFECTION_ARGS
         env:
+          INPUTS_INFECTION_ARGS: ${{ inputs.infection-args }}
           STRYKER_DASHBOARD_API_KEY: ${{ secrets.STRYKER_DASHBOARD_API_KEY }}

--- a/.github/workflows/infection.yml
+++ b/.github/workflows/infection.yml
@@ -68,7 +68,7 @@ jobs:
 
       - if: ${{ inputs.required-packages != '' }}
         name: Install required packages.
-        uses: yiisoft/actions/install-packages@ab62d6b3b0e0cff6c9724ec5a395bedb41c639a2
+        uses: yiisoft/actions/install-packages@master
         with:
           packages: ${{ inputs.required-packages }}
 

--- a/.github/workflows/infection.yml
+++ b/.github/workflows/infection.yml
@@ -38,6 +38,9 @@ on:
       STRYKER_DASHBOARD_API_KEY:
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   infection:
     name: PHP ${{ matrix.php }}-${{ matrix.os }}

--- a/.github/workflows/phpbench.yml
+++ b/.github/workflows/phpbench.yml
@@ -133,22 +133,56 @@ jobs:
           persist-credentials: false
 
       - name: "Baseline creation: Install dependencies with composer."
-        if: ${{ env.WITH_BENCH_BASELINE == '1' }}
-        run: $INPUTS_COMPOSER_COMMAND
+        if: ${{ env.WITH_BENCH_BASELINE == '1' && runner.os != 'Windows' }}
+        run: |
+          printf '%s\n' "$INPUTS_COMPOSER_COMMAND" > "$RUNNER_TEMP/composer-command.sh"
+          bash -e "$RUNNER_TEMP/composer-command.sh"
+        working-directory: default
+        env:
+          INPUTS_COMPOSER_COMMAND: ${{ inputs.composer-command }}
+
+      - name: "Baseline creation: Install dependencies with composer."
+        if: ${{ env.WITH_BENCH_BASELINE == '1' && runner.os == 'Windows' }}
+        shell: pwsh
+        run: |
+          Set-Content -Path "$env:RUNNER_TEMP\composer-command.ps1" -Value $env:INPUTS_COMPOSER_COMMAND
+          & "$env:RUNNER_TEMP\composer-command.ps1"
         working-directory: default
         env:
           INPUTS_COMPOSER_COMMAND: ${{ inputs.composer-command }}
 
       - name: "Baseline creation: Run PhpBench."
-        if: ${{ env.WITH_BENCH_BASELINE == '1' }}
+        if: ${{ env.WITH_BENCH_BASELINE == '1' && runner.os != 'Windows' }}
         run: vendor/bin/phpbench run --report="$INPUTS_REPORT" --config="$INPUTS_CONFIG_FILE" --tag=default
         working-directory: default
         env:
           INPUTS_REPORT: ${{ inputs.report }}
           INPUTS_CONFIG_FILE: ${{ inputs.config-file }}
 
+      - name: "Baseline creation: Run PhpBench."
+        if: ${{ env.WITH_BENCH_BASELINE == '1' && runner.os == 'Windows' }}
+        shell: pwsh
+        run: php vendor/bin/phpbench run --report="$env:INPUTS_REPORT" --config="$env:INPUTS_CONFIG_FILE" --tag=default
+        working-directory: default
+        env:
+          INPUTS_REPORT: ${{ inputs.report }}
+          INPUTS_CONFIG_FILE: ${{ inputs.config-file }}
+
       - name: Install dependencies with composer.
-        run: $INPUTS_COMPOSER_COMMAND
+        if: runner.os != 'Windows'
+        run: |
+          printf '%s\n' "$INPUTS_COMPOSER_COMMAND" > "$RUNNER_TEMP/composer-command.sh"
+          bash -e "$RUNNER_TEMP/composer-command.sh"
+        working-directory: ./current
+        env:
+          INPUTS_COMPOSER_COMMAND: ${{ inputs.composer-command }}
+
+      - name: Install dependencies with composer.
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          Set-Content -Path "$env:RUNNER_TEMP\composer-command.ps1" -Value $env:INPUTS_COMPOSER_COMMAND
+          & "$env:RUNNER_TEMP\composer-command.ps1"
         working-directory: ./current
         env:
           INPUTS_COMPOSER_COMMAND: ${{ inputs.composer-command }}
@@ -182,9 +216,9 @@ jobs:
         working-directory: ./current
         run: |
           if ($env:WITH_BENCH_BASELINE -eq '1') {
-            & php vendor/bin/phpbench run --report='$env:INPUTS_REPORT' --config=$env:INPUTS_CONFIG_FILE --assert="$env:INPUTS_BASELINE_ASSERTION" --ref=default | Out-File -FilePath phpbench.log -Encoding utf8
+            & php vendor/bin/phpbench run --report="$env:INPUTS_REPORT" --config="$env:INPUTS_CONFIG_FILE" --assert="$env:INPUTS_BASELINE_ASSERTION" --ref=default | Out-File -FilePath phpbench.log -Encoding utf8
           } else {
-            & php vendor/bin/phpbench run --report='$env:INPUTS_REPORT' --config=$env:INPUTS_CONFIG_FILE | Out-File -FilePath phpbench.log -Encoding utf8
+            & php vendor/bin/phpbench run --report="$env:INPUTS_REPORT" --config="$env:INPUTS_CONFIG_FILE" | Out-File -FilePath phpbench.log -Encoding utf8
           }
         env:
           INPUTS_REPORT: ${{ inputs.report }}

--- a/.github/workflows/phpbench.yml
+++ b/.github/workflows/phpbench.yml
@@ -52,6 +52,9 @@ on:
         required: false
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   phpbench:
     name: PHP ${{ matrix.php }}-${{ matrix.os }}
@@ -116,7 +119,7 @@ jobs:
         if: matrix.os == 'windows-latest'
         shell: pwsh
         run: |
-          if (("${{ github.event_name }}" -eq "pull_request") -and ("$env:GITHUB_REF" -ne "refs/heads/$env:GITHUB_EVENT_REPOSITORY_DEFAULT_BRANCH")) {
+          if (("$env:GITHUB_EVENT_NAME" -eq "pull_request") -and ("$env:GITHUB_REF" -ne "refs/heads/$env:GITHUB_EVENT_REPOSITORY_DEFAULT_BRANCH")) {
             Set-Content -Path $env:GITHUB_ENV -Value "WITH_BENCH_BASELINE=1" -NoNewline
           } else {
             Set-Content -Path $env:GITHUB_ENV -Value "WITH_BENCH_BASELINE=0" -NoNewline

--- a/.github/workflows/phpbench.yml
+++ b/.github/workflows/phpbench.yml
@@ -66,7 +66,7 @@ jobs:
 
     steps:
       - name: Install PHP with extensions.
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@b604ade2a87db23f8871b7182e69ec5e75effb45
         with:
           coverage: ${{ inputs.coverage }}
           extensions: ${{ inputs.extensions }}
@@ -75,9 +75,10 @@ jobs:
           tools: ${{ inputs.tools }}
 
       - name: Checkout.
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           path: ./current
+          persist-credentials: false
 
       - name: Determine composer cache directory on Linux.
         if: matrix.os == 'ubuntu-latest'
@@ -90,7 +91,7 @@ jobs:
         run: echo "COMPOSER_CACHE_DIR=~\AppData\Local\Composer" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
       - name: Cache dependencies installed with composer.
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
         with:
           path: ${{ env.COMPOSER_CACHE_DIR }}
           key: php${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}
@@ -103,42 +104,54 @@ jobs:
       - name: Check if we need to create a baseline for a PR (Linux).
         if: matrix.os == 'ubuntu-latest'
         run: |
-          if [[ "${{ github.event_name }}" == "pull_request" && "${{ github.ref }}" != "refs/heads/${{ github.event.repository.default_branch }}" ]]; then
+          if [[ "$GITHUB_EVENT_NAME" == "pull_request" && "$GITHUB_REF" != "refs/heads/$GITHUB_EVENT_REPOSITORY_DEFAULT_BRANCH" ]]; then
             echo "WITH_BENCH_BASELINE=1" >> $GITHUB_ENV
           else
             echo "WITH_BENCH_BASELINE=0" >> $GITHUB_ENV
           fi
+        env:
+          GITHUB_EVENT_REPOSITORY_DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
 
       - name: Check if we need to create a baseline for a PR (Windows).
         if: matrix.os == 'windows-latest'
         shell: pwsh
         run: |
-          if (("${{ github.event_name }}" -eq "pull_request") -and ("${{ github.ref }}" -ne "refs/heads/${{ github.event.repository.default_branch }}")) {
+          if (("${{ github.event_name }}" -eq "pull_request") -and ("$env:GITHUB_REF" -ne "refs/heads/$env:GITHUB_EVENT_REPOSITORY_DEFAULT_BRANCH")) {
             Set-Content -Path $env:GITHUB_ENV -Value "WITH_BENCH_BASELINE=1" -NoNewline
           } else {
             Set-Content -Path $env:GITHUB_ENV -Value "WITH_BENCH_BASELINE=0" -NoNewline
           }
+        env:
+          GITHUB_EVENT_REPOSITORY_DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
 
       - name: "Baseline creation: Checkout default branch."
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         if: ${{ env.WITH_BENCH_BASELINE == '1' }}
         with:
           path: default
           ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
 
       - name: "Baseline creation: Install dependencies with composer."
         if: ${{ env.WITH_BENCH_BASELINE == '1' }}
-        run: ${{ inputs.composer-command }}
+        run: $INPUTS_COMPOSER_COMMAND
         working-directory: default
+        env:
+          INPUTS_COMPOSER_COMMAND: ${{ inputs.composer-command }}
 
       - name: "Baseline creation: Run PhpBench."
         if: ${{ env.WITH_BENCH_BASELINE == '1' }}
-        run: vendor/bin/phpbench run --report='${{ inputs.report }}' --config=${{ inputs.config-file }} --tag=default
+        run: vendor/bin/phpbench run --report="$INPUTS_REPORT" --config="$INPUTS_CONFIG_FILE" --tag=default
         working-directory: default
+        env:
+          INPUTS_REPORT: ${{ inputs.report }}
+          INPUTS_CONFIG_FILE: ${{ inputs.config-file }}
 
       - name: Install dependencies with composer.
-        run: ${{ inputs.composer-command }}
+        run: $INPUTS_COMPOSER_COMMAND
         working-directory: ./current
+        env:
+          INPUTS_COMPOSER_COMMAND: ${{ inputs.composer-command }}
 
       - name: Copy PhpBench baseline data (Linux).
         if: ${{ env.WITH_BENCH_BASELINE == '1' && matrix.os == 'ubuntu-latest' }}
@@ -153,19 +166,27 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         working-directory: ./current
         run: |
-          if [ "${{ env.WITH_BENCH_BASELINE }}" == '1' ]; then
-            vendor/bin/phpbench run --report='${{ inputs.report }}' --config=${{ inputs.config-file }} --ref=default --assert="${{ inputs.baseline-assertion }}" > phpbench.log
+          if [ "$WITH_BENCH_BASELINE" == '1' ]; then
+            vendor/bin/phpbench run --report="$INPUTS_REPORT" --config="$INPUTS_CONFIG_FILE" --ref=default --assert="$INPUTS_BASELINE_ASSERTION" > phpbench.log
           else
-            vendor/bin/phpbench run --report='${{ inputs.report }}' --config=${{ inputs.config-file }} > phpbench.log
+            vendor/bin/phpbench run --report="$INPUTS_REPORT" --config="$INPUTS_CONFIG_FILE" > phpbench.log
           fi
+        env:
+          INPUTS_REPORT: ${{ inputs.report }}
+          INPUTS_CONFIG_FILE: ${{ inputs.config-file }}
+          INPUTS_BASELINE_ASSERTION: ${{ inputs.baseline-assertion }}
 
       - name: "Run PhpBench (Windows)."
         if: matrix.os == 'windows-latest'
         shell: pwsh
         working-directory: ./current
         run: |
-          if (${{ env.WITH_BENCH_BASELINE }} -eq '1') {
-            & php vendor/bin/phpbench run --report='${{ inputs.report }}' --config=${{ inputs.config-file }} --assert="${{ inputs.baseline-assertion }}" --ref=default | Out-File -FilePath phpbench.log -Encoding utf8
+          if ($env:WITH_BENCH_BASELINE -eq '1') {
+            & php vendor/bin/phpbench run --report='$env:INPUTS_REPORT' --config=$env:INPUTS_CONFIG_FILE --assert="$env:INPUTS_BASELINE_ASSERTION" --ref=default | Out-File -FilePath phpbench.log -Encoding utf8
           } else {
-            & php vendor/bin/phpbench run --report='${{ inputs.report }}' --config=${{ inputs.config-file }} | Out-File -FilePath phpbench.log -Encoding utf8
+            & php vendor/bin/phpbench run --report='$env:INPUTS_REPORT' --config=$env:INPUTS_CONFIG_FILE | Out-File -FilePath phpbench.log -Encoding utf8
           }
+        env:
+          INPUTS_REPORT: ${{ inputs.report }}
+          INPUTS_CONFIG_FILE: ${{ inputs.config-file }}
+          INPUTS_BASELINE_ASSERTION: ${{ inputs.baseline-assertion }}

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -27,6 +27,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   phpstan:
     name: PHP ${{ matrix.php }}-${{ matrix.os }}

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -40,10 +40,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
 
       - name: Install PHP with extensions
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@b604ade2a87db23f8871b7182e69ec5e75effb45
         with:
           coverage: xdebug
           extensions: ${{ inputs.extensions }}
@@ -51,7 +53,9 @@ jobs:
           php-version: ${{ matrix.php }}
 
       - name: Install Composer dependencies
-        uses: ramsey/composer-install@v4
+        uses: ramsey/composer-install@26d8a556604053a9612623447203a691f406fbe6
 
       - name: Run static analysis
-        run: vendor/bin/phpstan analyse --configuration=${{ inputs.phpstan-config }}
+        run: vendor/bin/phpstan analyse --configuration="$INPUTS_PHPSTAN_CONFIG"
+        env:
+          INPUTS_PHPSTAN_CONFIG: ${{ inputs.phpstan-config }}

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -78,10 +78,12 @@ jobs:
 
     steps:
       - name: Checkout.
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          persist-credentials: false
 
       - name: Install PHP with extensions.
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@b604ade2a87db23f8871b7182e69ec5e75effb45
         with:
           coverage: ${{ inputs.coverage }}
           extensions: ${{ inputs.extensions }}
@@ -98,7 +100,7 @@ jobs:
         run: echo "COMPOSER_CACHE_DIR=~\AppData\Local\Composer" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
       - name: Cache dependencies installed with composer.
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
         with:
           path: ${{ env.COMPOSER_CACHE_DIR }}
           key: php${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}
@@ -107,24 +109,30 @@ jobs:
 
       - name: Install dependencies with Composer
         if: ${{ !inputs.prefer-lowest }}
-        run: ${{ inputs.composer-command }}
+        run: $INPUTS_COMPOSER_COMMAND
+        env:
+          INPUTS_COMPOSER_COMMAND: ${{ inputs.composer-command }}
 
       - name: Install dependencies with Composer (prefer lowest)
         if: ${{ inputs.prefer-lowest }}
-        run: ${{ inputs.composer-command }} --prefer-lowest
+        run: $INPUTS_COMPOSER_COMMAND --prefer-lowest
+        env:
+          INPUTS_COMPOSER_COMMAND: ${{ inputs.composer-command }}
 
       - if: ${{ inputs.required-packages != '' }}
         name: Install required packages.
-        uses: yiisoft/actions/install-packages@master
+        uses: yiisoft/actions/install-packages@ab62d6b3b0e0cff6c9724ec5a395bedb41c639a2
         with:
           packages: ${{ inputs.required-packages }}
 
       - name: Run tests with phpunit with code coverage.
-        run: vendor/bin/phpunit --coverage-clover=coverage.xml --colors=always --configuration ${{ inputs.phpunitConfig }}
+        run: vendor/bin/phpunit --coverage-clover=coverage.xml --colors=always --configuration "$INPUTS_PHPUNIT_CONFIG"
+        env:
+          INPUTS_PHPUNIT_CONFIG: ${{ inputs.phpunitConfig }}
 
       - name: Upload coverage to Codecov.
         if: matrix.os == 'ubuntu-latest'
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238
         with:
           token: ${{ secrets.CODECOV_TOKEN || secrets.codecovToken }}
           files: ./coverage.xml

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -65,6 +65,9 @@ on:
         description: Deprecated, use CODECOV_TOKEN
         required: false
 
+permissions:
+  contents: read
+
 jobs:
   phpunit:
     name: PHP ${{ matrix.php }}-${{ matrix.os }}

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -108,14 +108,36 @@ jobs:
             php${{ matrix.php }}-composer-
 
       - name: Install dependencies with Composer
-        if: ${{ !inputs.prefer-lowest }}
-        run: $INPUTS_COMPOSER_COMMAND
+        if: ${{ !inputs.prefer-lowest && runner.os != 'Windows' }}
+        run: |
+          printf '%s\n' "$INPUTS_COMPOSER_COMMAND" > "$RUNNER_TEMP/composer-command.sh"
+          bash -e "$RUNNER_TEMP/composer-command.sh"
+        env:
+          INPUTS_COMPOSER_COMMAND: ${{ inputs.composer-command }}
+
+      - name: Install dependencies with Composer
+        if: ${{ !inputs.prefer-lowest && runner.os == 'Windows' }}
+        shell: powershell
+        run: |
+          Set-Content -Path "$env:RUNNER_TEMP\composer-command.ps1" -Value $env:INPUTS_COMPOSER_COMMAND
+          & "$env:RUNNER_TEMP\composer-command.ps1"
         env:
           INPUTS_COMPOSER_COMMAND: ${{ inputs.composer-command }}
 
       - name: Install dependencies with Composer (prefer lowest)
-        if: ${{ inputs.prefer-lowest }}
-        run: $INPUTS_COMPOSER_COMMAND --prefer-lowest
+        if: ${{ inputs.prefer-lowest && runner.os != 'Windows' }}
+        run: |
+          printf '%s --prefer-lowest\n' "$INPUTS_COMPOSER_COMMAND" > "$RUNNER_TEMP/composer-command.sh"
+          bash -e "$RUNNER_TEMP/composer-command.sh"
+        env:
+          INPUTS_COMPOSER_COMMAND: ${{ inputs.composer-command }}
+
+      - name: Install dependencies with Composer (prefer lowest)
+        if: ${{ inputs.prefer-lowest && runner.os == 'Windows' }}
+        shell: powershell
+        run: |
+          Set-Content -Path "$env:RUNNER_TEMP\composer-command.ps1" -Value "$env:INPUTS_COMPOSER_COMMAND --prefer-lowest"
+          & "$env:RUNNER_TEMP\composer-command.ps1"
         env:
           INPUTS_COMPOSER_COMMAND: ${{ inputs.composer-command }}
 

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -121,7 +121,7 @@ jobs:
 
       - if: ${{ inputs.required-packages != '' }}
         name: Install required packages.
-        uses: yiisoft/actions/install-packages@ab62d6b3b0e0cff6c9724ec5a395bedb41c639a2
+        uses: yiisoft/actions/install-packages@master
         with:
           packages: ${{ inputs.required-packages }}
 

--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -47,10 +47,12 @@ jobs:
 
     steps:
       - name: Checkout.
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          persist-credentials: false
 
       - name: Install PHP with extensions.
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@b604ade2a87db23f8871b7182e69ec5e75effb45
         with:
           coverage: none
           php-version: ${{ matrix.php }}
@@ -61,7 +63,7 @@ jobs:
         run: echo "COMPOSER_CACHE_DIR=$(composer config cache-dir)" >> $GITHUB_ENV
 
       - name: Cache dependencies installed with composer.
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
         with:
           path: ${{ env.COMPOSER_CACHE_DIR }}
           key: php${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}
@@ -69,13 +71,18 @@ jobs:
             php${{ matrix.php }}-composer-
 
       - name: Install dependencies with composer.
-        run: ${{ inputs.composer-command }}
+        run: $INPUTS_COMPOSER_COMMAND
+        env:
+          INPUTS_COMPOSER_COMMAND: ${{ inputs.composer-command }}
 
       - if: ${{ inputs.required-packages != '' }}
         name: Install required packages.
-        uses: yiisoft/actions/install-packages@master
+        uses: yiisoft/actions/install-packages@ab62d6b3b0e0cff6c9724ec5a395bedb41c639a2
         with:
           packages: ${{ inputs.required-packages }}
 
       - name: Static analysis.
-        run: vendor/bin/psalm --config=${{ inputs.psalm-config }} --shepherd --stats --output-format=github --php-version=${{ matrix.php }}
+        run: vendor/bin/psalm --config="$INPUTS_PSALM_CONFIG" --shepherd --stats --output-format=github --php-version="$MATRIX_PHP"
+        env:
+          INPUTS_PSALM_CONFIG: ${{ inputs.psalm-config }}
+          MATRIX_PHP: ${{ matrix.php }}

--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -77,7 +77,7 @@ jobs:
 
       - if: ${{ inputs.required-packages != '' }}
         name: Install required packages.
-        uses: yiisoft/actions/install-packages@ab62d6b3b0e0cff6c9724ec5a395bedb41c639a2
+        uses: yiisoft/actions/install-packages@master
         with:
           packages: ${{ inputs.required-packages }}
 

--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -34,6 +34,9 @@ on:
         required: false
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   psalm:
     name: PHP ${{ matrix.php }}-${{ matrix.os }}

--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -71,7 +71,19 @@ jobs:
             php${{ matrix.php }}-composer-
 
       - name: Install dependencies with composer.
-        run: $INPUTS_COMPOSER_COMMAND
+        if: runner.os != 'Windows'
+        run: |
+          printf '%s\n' "$INPUTS_COMPOSER_COMMAND" > "$RUNNER_TEMP/composer-command.sh"
+          bash -e "$RUNNER_TEMP/composer-command.sh"
+        env:
+          INPUTS_COMPOSER_COMMAND: ${{ inputs.composer-command }}
+
+      - name: Install dependencies with composer.
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          Set-Content -Path "$env:RUNNER_TEMP\composer-command.ps1" -Value $env:INPUTS_COMPOSER_COMMAND
+          & "$env:RUNNER_TEMP\composer-command.ps1"
         env:
           INPUTS_COMPOSER_COMMAND: ${{ inputs.composer-command }}
 

--- a/.github/workflows/rector-cs.yml
+++ b/.github/workflows/rector-cs.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Install required packages
         if: ${{ inputs.required-packages != '' }}
-        uses: yiisoft/actions/install-packages@ab62d6b3b0e0cff6c9724ec5a395bedb41c639a2
+        uses: yiisoft/actions/install-packages@master
         with:
           packages: ${{ inputs.required-packages }}
 

--- a/.github/workflows/rector-cs.yml
+++ b/.github/workflows/rector-cs.yml
@@ -26,21 +26,23 @@ jobs:
       contents: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          persist-credentials: false
 
       - name: Install PHP with extensions
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@b604ade2a87db23f8871b7182e69ec5e75effb45
         with:
           php-version: ${{ inputs.php }}
           extensions: ${{ inputs.extensions }}
           coverage: none
 
       - name: Install Composer dependencies
-        uses: ramsey/composer-install@v4
+        uses: ramsey/composer-install@26d8a556604053a9612623447203a691f406fbe6
 
       - name: Install required packages
         if: ${{ inputs.required-packages != '' }}
-        uses: yiisoft/actions/install-packages@master
+        uses: yiisoft/actions/install-packages@ab62d6b3b0e0cff6c9724ec5a395bedb41c639a2
         with:
           packages: ${{ inputs.required-packages }}
 
@@ -50,8 +52,13 @@ jobs:
       - name: Run Rector
         run: ./vendor/bin/rector --output-format=github
 
+      - name: Configure Git credentials
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: git config --global credential.helper '!f() { echo username=x-access-token; echo password=$GH_TOKEN; }; f'
+
       - name: Commit changes
-        uses: stefanzweifel/git-auto-commit-action@v7
+        uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9
         with:
           commit_message: "Apply PHP CS Fixer and Rector changes (CI)"
           file_pattern: '*.php'

--- a/.github/workflows/rector-cs.yml
+++ b/.github/workflows/rector-cs.yml
@@ -59,6 +59,8 @@ jobs:
 
       - name: Commit changes
         uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9
+        env:
+          GH_TOKEN: ${{ github.token }}
         with:
           commit_message: "Apply PHP CS Fixer and Rector changes (CI)"
           file_pattern: '*.php'

--- a/.github/workflows/rector-cs.yml
+++ b/.github/workflows/rector-cs.yml
@@ -18,12 +18,15 @@ on:
         required: false
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   rector-cs:
     name: PHP ${{ inputs.php }}
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: write # Required to push PHP CS Fixer and Rector changes back to the branch.
     steps:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
@@ -58,10 +61,13 @@ jobs:
         run: git config --global credential.helper '!f() { echo username=x-access-token; echo password=$GH_TOKEN; }; f'
 
       - name: Commit changes
-        uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9
         env:
           GH_TOKEN: ${{ github.token }}
-        with:
-          commit_message: "Apply PHP CS Fixer and Rector changes (CI)"
-          file_pattern: '*.php'
-          disable_globbing: true
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add -- '*.php'
+          git diff --cached --quiet || (
+            git commit -m "Apply PHP CS Fixer and Rector changes (CI)"
+            git push
+          )

--- a/.github/workflows/rector.yml
+++ b/.github/workflows/rector.yml
@@ -53,14 +53,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           token: ${{ secrets.token || github.token }}
           ref: ${{ github.head_ref }}
           repository: ${{ inputs.repository }}
+          persist-credentials: false
 
       - name: Install PHP with extensions
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@b604ade2a87db23f8871b7182e69ec5e75effb45
         with:
           php-version: ${{ matrix.php }}
           extensions: ${{ inputs.extensions }}
@@ -70,7 +71,7 @@ jobs:
         run: echo "COMPOSER_CACHE_DIR=$(composer config cache-dir)" >> $GITHUB_ENV
 
       - name: Cache dependencies installed with composer
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
         with:
           path: ${{ env.COMPOSER_CACHE_DIR }}
           key: php${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}
@@ -78,11 +79,13 @@ jobs:
             php${{ matrix.php }}-composer-
 
       - name: Install dependencies with composer
-        run: ${{ inputs.composer-command }}
+        run: $INPUTS_COMPOSER_COMMAND
+        env:
+          INPUTS_COMPOSER_COMMAND: ${{ inputs.composer-command }}
 
       - if: ${{ inputs.required-packages != '' }}
         name: Install required packages.
-        uses: yiisoft/actions/install-packages@master
+        uses: yiisoft/actions/install-packages@ab62d6b3b0e0cff6c9724ec5a395bedb41c639a2
         with:
           packages: ${{ inputs.required-packages }}
 
@@ -94,8 +97,13 @@ jobs:
 
       - run: vendor/bin/rector process --ansi --output-format=github
 
+      - name: Configure Git credentials
+        env:
+          GH_TOKEN: ${{ secrets.token || github.token }}
+        run: git config --global credential.helper '!f() { echo username=x-access-token; echo password=$GH_TOKEN; }; f'
+
       - name: Commit changes
-        uses: stefanzweifel/git-auto-commit-action@v7
+        uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9
         with:
           commit_message: "Apply Rector changes (CI)"
           file_pattern: '*.php'

--- a/.github/workflows/rector.yml
+++ b/.github/workflows/rector.yml
@@ -40,11 +40,16 @@ on:
         description: GitHub classic token with repo and workflow scopes
         required: false
 
+permissions:
+  contents: read
+
 jobs:
   rector:
     name: PHP ${{ matrix.php }}-${{ matrix.os }}
 
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: write # Required to push Rector changes back to the branch.
 
     strategy:
       matrix:
@@ -115,10 +120,13 @@ jobs:
         run: git config --global credential.helper '!f() { echo username=x-access-token; echo password=$GH_TOKEN; }; f'
 
       - name: Commit changes
-        uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9
         env:
           GH_TOKEN: ${{ secrets.token || github.token }}
-        with:
-          commit_message: "Apply Rector changes (CI)"
-          file_pattern: '*.php'
-          disable_globbing: true
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add -- '*.php'
+          git diff --cached --quiet || (
+            git commit -m "Apply Rector changes (CI)"
+            git push
+          )

--- a/.github/workflows/rector.yml
+++ b/.github/workflows/rector.yml
@@ -85,7 +85,7 @@ jobs:
 
       - if: ${{ inputs.required-packages != '' }}
         name: Install required packages.
-        uses: yiisoft/actions/install-packages@ab62d6b3b0e0cff6c9724ec5a395bedb41c639a2
+        uses: yiisoft/actions/install-packages@master
         with:
           packages: ${{ inputs.required-packages }}
 

--- a/.github/workflows/rector.yml
+++ b/.github/workflows/rector.yml
@@ -79,7 +79,19 @@ jobs:
             php${{ matrix.php }}-composer-
 
       - name: Install dependencies with composer
-        run: $INPUTS_COMPOSER_COMMAND
+        if: runner.os != 'Windows'
+        run: |
+          printf '%s\n' "$INPUTS_COMPOSER_COMMAND" > "$RUNNER_TEMP/composer-command.sh"
+          bash -e "$RUNNER_TEMP/composer-command.sh"
+        env:
+          INPUTS_COMPOSER_COMMAND: ${{ inputs.composer-command }}
+
+      - name: Install dependencies with composer
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          Set-Content -Path "$env:RUNNER_TEMP\composer-command.ps1" -Value $env:INPUTS_COMPOSER_COMMAND
+          & "$env:RUNNER_TEMP\composer-command.ps1"
         env:
           INPUTS_COMPOSER_COMMAND: ${{ inputs.composer-command }}
 
@@ -104,6 +116,8 @@ jobs:
 
       - name: Commit changes
         uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9
+        env:
+          GH_TOKEN: ${{ secrets.token || github.token }}
         with:
           commit_message: "Apply Rector changes (CI)"
           file_pattern: '*.php'

--- a/.github/workflows/roave-infection.yml
+++ b/.github/workflows/roave-infection.yml
@@ -101,7 +101,7 @@ jobs:
 
       - if: ${{ inputs.required-packages != '' }}
         name: Install required packages.
-        uses: yiisoft/actions/install-packages@ab62d6b3b0e0cff6c9724ec5a395bedb41c639a2
+        uses: yiisoft/actions/install-packages@master
         with:
           packages: ${{ inputs.required-packages }}
 

--- a/.github/workflows/roave-infection.yml
+++ b/.github/workflows/roave-infection.yml
@@ -58,6 +58,9 @@ on:
       STRYKER_DASHBOARD_API_KEY:
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   roave-infection:
     name: PHP ${{ matrix.php }}-${{ matrix.os }}

--- a/.github/workflows/roave-infection.yml
+++ b/.github/workflows/roave-infection.yml
@@ -95,7 +95,19 @@ jobs:
             php${{ matrix.php }}-composer
 
       - name: Install dependencies with composer.
-        run: $INPUTS_COMPOSER_COMMAND
+        if: runner.os != 'Windows'
+        run: |
+          printf '%s\n' "$INPUTS_COMPOSER_COMMAND" > "$RUNNER_TEMP/composer-command.sh"
+          bash -e "$RUNNER_TEMP/composer-command.sh"
+        env:
+          INPUTS_COMPOSER_COMMAND: ${{ inputs.composer-command }}
+
+      - name: Install dependencies with composer.
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          Set-Content -Path "$env:RUNNER_TEMP\composer-command.ps1" -Value $env:INPUTS_COMPOSER_COMMAND
+          & "$env:RUNNER_TEMP\composer-command.ps1"
         env:
           INPUTS_COMPOSER_COMMAND: ${{ inputs.composer-command }}
 

--- a/.github/workflows/roave-infection.yml
+++ b/.github/workflows/roave-infection.yml
@@ -71,10 +71,12 @@ jobs:
 
     steps:
       - name: Checkout.
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          persist-credentials: false
 
       - name: Install PHP with extensions.
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@b604ade2a87db23f8871b7182e69ec5e75effb45
         with:
           coverage: pcov
           extensions: ${{ inputs.extensions }}
@@ -85,7 +87,7 @@ jobs:
         run: echo "COMPOSER_CACHE_DIR=$(composer config cache-dir)" >> $GITHUB_ENV
 
       - name: Cache dependencies installed with composer.
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
         with:
           path: ${{ env.COMPOSER_CACHE_DIR }}
           key: php${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}
@@ -93,16 +95,22 @@ jobs:
             php${{ matrix.php }}-composer
 
       - name: Install dependencies with composer.
-        run: ${{ inputs.composer-command }}
+        run: $INPUTS_COMPOSER_COMMAND
+        env:
+          INPUTS_COMPOSER_COMMAND: ${{ inputs.composer-command }}
 
       - if: ${{ inputs.required-packages != '' }}
         name: Install required packages.
-        uses: yiisoft/actions/install-packages@master
+        uses: yiisoft/actions/install-packages@ab62d6b3b0e0cff6c9724ec5a395bedb41c639a2
         with:
           packages: ${{ inputs.required-packages }}
 
       - name: Run roave infection.
         run: |
-          vendor/bin/${{ inputs.bin-name }} --threads=${{ inputs.threads }} --min-msi=${{ inputs.min-msi }} --min-covered-msi=${{ inputs.min-covered-msi }} --ignore-msi-with-no-mutations
+          "vendor/bin/$INPUTS_BIN_NAME" --threads="$INPUTS_THREADS" --min-msi="$INPUTS_MIN_MSI" --min-covered-msi="$INPUTS_MIN_COVERED_MSI" --ignore-msi-with-no-mutations
         env:
+          INPUTS_BIN_NAME: ${{ inputs.bin-name }}
+          INPUTS_THREADS: ${{ inputs.threads }}
+          INPUTS_MIN_MSI: ${{ inputs.min-msi }}
+          INPUTS_MIN_COVERED_MSI: ${{ inputs.min-covered-msi }}
           STRYKER_DASHBOARD_API_KEY: ${{ secrets.STRYKER_DASHBOARD_API_KEY }}

--- a/.github/workflows/update-readme-packages.yml
+++ b/.github/workflows/update-readme-packages.yml
@@ -113,6 +113,8 @@ jobs:
         run: git config --global credential.helper '!f() { echo username=x-access-token; echo password=$GH_TOKEN; }; f'
 
       - name: Commit changes
+        env:
+          GH_TOKEN: ${{ secrets.TOKEN || github.token }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/update-readme-packages.yml
+++ b/.github/workflows/update-readme-packages.yml
@@ -7,6 +7,9 @@ on:
         description: GitHub token for authentication in workflows.
         required: false
 
+permissions:
+  contents: read
+
 jobs:
   update-readme-packages:
     name: Update README packages
@@ -14,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     permissions:
-      contents: write
+      contents: write # Required to push generated README package lists back to the branch.
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/update-readme-packages.yml
+++ b/.github/workflows/update-readme-packages.yml
@@ -18,14 +18,15 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           token: ${{ secrets.TOKEN || github.token }}
           ref: ${{ github.head_ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          persist-credentials: false
 
       - name: Update package lists in README.md
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd
         with:
           script: |
             const fs = require('fs');
@@ -105,6 +106,11 @@ jobs:
 
             fs.writeFileSync('README.md', readme);
             console.log('README.md updated successfully');
+
+      - name: Configure Git credentials
+        env:
+          GH_TOKEN: ${{ secrets.TOKEN || github.token }}
+        run: git config --global credential.helper '!f() { echo username=x-access-token; echo password=$GH_TOKEN; }; f'
 
       - name: Commit changes
         run: |

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -8,7 +8,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  actions: read
+  actions: read # Required by zizmor when reading workflow metadata through the API.
   contents: read
 
 jobs:

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,5 @@
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        "yiisoft/*": any

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,4 +1,12 @@
 rules:
+  unpinned-images:
+    ignore:
+      - db-mariadb.yml
+      - db-mssql.yml
+      - db-mutation.yml
+      - db-mysql.yml
+      - db-oracle.yml
+      - db-pgsql.yml
   unpinned-uses:
     config:
       policies:

--- a/db/environment-linux/action.yml
+++ b/db/environment-linux/action.yml
@@ -8,14 +8,22 @@ runs:
       if: github.event_name == 'pull_request'
       shell: bash
       run: |
-        echo "WORK_PACKAGE_URL=https://github.com/${{ github.event.pull_request.head.repo.owner.login }}/" >> $GITHUB_ENV
-        echo "BRANCH_NAME=${{ github.head_ref }}" >> $GITHUB_ENV
-        echo "FULL_BRANCH_NAME=dev-${{ github.head_ref }}" >> $GITHUB_ENV
+        {
+          echo "WORK_PACKAGE_URL=https://github.com/${GITHUB_EVENT_PULL_REQUEST_HEAD_REPO_OWNER_LOGIN}/"
+          echo "BRANCH_NAME=${GITHUB_HEAD_REF}"
+          echo "FULL_BRANCH_NAME=dev-${GITHUB_HEAD_REF}"
+        } >> "$GITHUB_ENV"
+      env:
+        GITHUB_EVENT_PULL_REQUEST_HEAD_REPO_OWNER_LOGIN: ${{ github.event.pull_request.head.repo.owner.login }}
 
     - name: Set environment variable for work package url (push) ubuntu.
       if: github.event_name == 'push'
       shell: bash
       run: |
-        echo "WORK_PACKAGE_URL=https://github.com/${{ github.event.repository.owner.login }}/" >> $GITHUB_ENV
-        echo "BRANCH_NAME=${{ github.ref_name }}" >> $GITHUB_ENV
-        echo "FULL_BRANCH_NAME=dev-${{ github.ref_name }}" >> $GITHUB_ENV
+        {
+          echo "WORK_PACKAGE_URL=https://github.com/${GITHUB_EVENT_REPOSITORY_OWNER_LOGIN}/"
+          echo "BRANCH_NAME=${GITHUB_REF_NAME}"
+          echo "FULL_BRANCH_NAME=dev-${GITHUB_REF_NAME}"
+        } >> "$GITHUB_ENV"
+      env:
+        GITHUB_EVENT_REPOSITORY_OWNER_LOGIN: ${{ github.event.repository.owner.login }}

--- a/db/environment-windows/action.yml
+++ b/db/environment-windows/action.yml
@@ -6,16 +6,22 @@ runs:
   steps:
     - name: Set environment variable for work package url (pull request) windows.
       if: github.event_name == 'pull_request'
-      shell: pwsh
-      run: |
-        echo "WORK_PACKAGE_URL=https://github.com/${{ github.event.pull_request.head.repo.owner.login }}/" | Out-File -FilePath $env:GITHUB_ENV -Append
-        echo "BRANCH_NAME=${{ github.head_ref }}" | Out-File -FilePath $env:GITHUB_ENV -Append
-        echo "FULL_BRANCH_NAME=dev-${{ github.head_ref }}" | Out-File -FilePath $env:GITHUB_ENV -Append
+      uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd
+      env:
+        GITHUB_EVENT_PULL_REQUEST_HEAD_REPO_OWNER_LOGIN: ${{ github.event.pull_request.head.repo.owner.login }}
+      with:
+        script: |
+          core.exportVariable('WORK_PACKAGE_URL', `https://github.com/${process.env.GITHUB_EVENT_PULL_REQUEST_HEAD_REPO_OWNER_LOGIN}/`);
+          core.exportVariable('BRANCH_NAME', process.env.GITHUB_HEAD_REF);
+          core.exportVariable('FULL_BRANCH_NAME', `dev-${process.env.GITHUB_HEAD_REF}`);
 
     - name: Set environment variable for work package url (push) windows.
       if: github.event_name == 'push'
-      shell: pwsh
-      run: |
-        echo "WORK_PACKAGE_URL=https://github.com/${{ github.event.repository.owner.login }}/" | Out-File -FilePath $env:GITHUB_ENV -Append
-        echo "BRANCH_NAME=${{ github.ref_name }}" | Out-File -FilePath $env:GITHUB_ENV -Append
-        echo "FULL_BRANCH_NAME=dev-${{ github.ref_name }}" | Out-File -FilePath $env:GITHUB_ENV -Append
+      uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd
+      env:
+        GITHUB_EVENT_REPOSITORY_OWNER_LOGIN: ${{ github.event.repository.owner.login }}
+      with:
+        script: |
+          core.exportVariable('WORK_PACKAGE_URL', `https://github.com/${process.env.GITHUB_EVENT_REPOSITORY_OWNER_LOGIN}/`);
+          core.exportVariable('BRANCH_NAME', process.env.GITHUB_REF_NAME);
+          core.exportVariable('FULL_BRANCH_NAME', `dev-${process.env.GITHUB_REF_NAME}`);

--- a/db/subpackage-install/action.yml
+++ b/db/subpackage-install/action.yml
@@ -25,63 +25,93 @@ runs:
       if: ${{ github.event_name == 'pull_request' }}
       shell: bash
       run: |
-        if git ls-remote --heads ${{ inputs.WORK_PACKAGE_URL }}${{ inputs.CURRENT_PACKAGE }} ${{ inputs.BRANCH_NAME }} | grep ${{ inputs.BRANCH_NAME }};
+        if git ls-remote --heads "${WORK_PACKAGE_URL}${CURRENT_PACKAGE}" "${BRANCH_NAME}" | grep --fixed-strings "${BRANCH_NAME}";
         then echo "BRANCH_EXISTS=1" >> $GITHUB_ENV; else echo "BRANCH_EXISTS=0" >> $GITHUB_ENV; fi
+      env:
+        BRANCH_NAME: ${{ inputs.BRANCH_NAME }}
+        CURRENT_PACKAGE: ${{ inputs.CURRENT_PACKAGE }}
+        WORK_PACKAGE_URL: ${{ inputs.WORK_PACKAGE_URL }}
 
     - name: Install from fork and branch exists.
       if: ${{ github.event.pull_request.head.repo.fork && env.BRANCH_EXISTS == 1 }}
       shell: bash
       run: |
         echo "Pull Request - Install from fork and branch exists."
-        composer config repositories.yiisoft/${{ inputs.CURRENT_PACKAGE }} git ${{ inputs.WORK_PACKAGE_URL }}${{ inputs.CURRENT_PACKAGE }}
-        COMPOSER_ROOT_VERSION=${{ inputs.COMPOSER_ROOT_VERSION }} composer require "yiisoft/${{ inputs.CURRENT_PACKAGE }}:${{ inputs.FULL_BRANCH_NAME }} as ${{ inputs.COMPOSER_ROOT_VERSION }}" --no-interaction --no-progress --optimize-autoloader --ansi
+        composer config "repositories.yiisoft/${CURRENT_PACKAGE}" git "${WORK_PACKAGE_URL}${CURRENT_PACKAGE}"
+        COMPOSER_ROOT_VERSION="${COMPOSER_ROOT_VERSION}" composer require "yiisoft/${CURRENT_PACKAGE}:${FULL_BRANCH_NAME} as ${COMPOSER_ROOT_VERSION}" --no-interaction --no-progress --optimize-autoloader --ansi
+      env:
+        COMPOSER_ROOT_VERSION: ${{ inputs.COMPOSER_ROOT_VERSION }}
+        CURRENT_PACKAGE: ${{ inputs.CURRENT_PACKAGE }}
+        FULL_BRANCH_NAME: ${{ inputs.FULL_BRANCH_NAME }}
+        WORK_PACKAGE_URL: ${{ inputs.WORK_PACKAGE_URL }}
 
     - name: Install from fork and branch not exists.
       if: ${{ github.event.pull_request.head.repo.fork && env.BRANCH_EXISTS == 0 }}
       shell: bash
       run: |
         echo "Pull Request - Install from fork and branch not exists."
-        composer require yiisoft/${{ inputs.CURRENT_PACKAGE }}:dev-master --no-interaction --no-progress --optimize-autoloader --ansi
+        composer require "yiisoft/${CURRENT_PACKAGE}:dev-master" --no-interaction --no-progress --optimize-autoloader --ansi
+      env:
+        CURRENT_PACKAGE: ${{ inputs.CURRENT_PACKAGE }}
 
     - name: Install from branch and branch exists.
       if: ${{ github.event_name == 'pull_request' && ! github.event.pull_request.head.repo.fork  && env.BRANCH_EXISTS == 1 }}
       shell: bash
       run: |
         echo "Pull Request - Install from branch and branch exists."
-        composer require "yiisoft/${{ inputs.CURRENT_PACKAGE }}:${{ inputs.FULL_BRANCH_NAME }} as ${{ inputs.COMPOSER_ROOT_VERSION }}" --no-interaction --no-progress --optimize-autoloader --ansi
+        composer require "yiisoft/${CURRENT_PACKAGE}:${FULL_BRANCH_NAME} as ${COMPOSER_ROOT_VERSION}" --no-interaction --no-progress --optimize-autoloader --ansi
+      env:
+        COMPOSER_ROOT_VERSION: ${{ inputs.COMPOSER_ROOT_VERSION }}
+        CURRENT_PACKAGE: ${{ inputs.CURRENT_PACKAGE }}
+        FULL_BRANCH_NAME: ${{ inputs.FULL_BRANCH_NAME }}
 
     - name: Install from master and branch not exists.
       if: ${{ github.event.pull_request.head.repo.full_name == 'yiisoft/db' && env.BRANCH_EXISTS != 1 }}
       shell: bash
       run: |
         echo "Pull Request - Install from master and branch not exists."
-        composer require yiisoft/${{ inputs.CURRENT_PACKAGE }}:dev-master --no-interaction --no-progress --optimize-autoloader --ansi
+        composer require "yiisoft/${CURRENT_PACKAGE}:dev-master" --no-interaction --no-progress --optimize-autoloader --ansi
+      env:
+        CURRENT_PACKAGE: ${{ inputs.CURRENT_PACKAGE }}
 
     - name: Install from not fork and branch not exists.
       if: ${{ github.event_name == 'pull_request' && ! github.event.pull_request.head.repo.fork  && env.BRANCH_EXISTS == 0 }}
       shell: bash
       run: |
         echo "Pull Request - Install from branch and branch exists."
-        composer require yiisoft/${{ inputs.CURRENT_PACKAGE }}:dev-master --no-interaction --no-progress --optimize-autoloader --ansi
+        composer require "yiisoft/${CURRENT_PACKAGE}:dev-master" --no-interaction --no-progress --optimize-autoloader --ansi
+      env:
+        CURRENT_PACKAGE: ${{ inputs.CURRENT_PACKAGE }}
 
     - name: Check exist branch (push).
       if: ${{ github.event_name == 'push' }}
       shell: bash
       run: |
-        if git ls-remote --heads ${{ inputs.WORK_PACKAGE_URL }}${{ inputs.CURRENT_PACKAGE }} ${{ inputs.BRANCH_NAME }} | grep ${{ inputs.BRANCH_NAME }};
+        if git ls-remote --heads "${WORK_PACKAGE_URL}${CURRENT_PACKAGE}" "${BRANCH_NAME}" | grep --fixed-strings "${BRANCH_NAME}";
         then echo "BRANCH_EXISTS=1" >> $GITHUB_ENV; else echo "BRANCH_EXISTS=0" >> $GITHUB_ENV; fi
+      env:
+        BRANCH_NAME: ${{ inputs.BRANCH_NAME }}
+        CURRENT_PACKAGE: ${{ inputs.CURRENT_PACKAGE }}
+        WORK_PACKAGE_URL: ${{ inputs.WORK_PACKAGE_URL }}
 
     - name: Install from fork and branch exists (push)
       if: ${{ github.event_name == 'push' && env.BRANCH_EXISTS == 1 }}
       shell: bash
       run: |
         echo "Push - Install from fork and branch exists."
-        composer config repositories.yiisoft/${{ inputs.CURRENT_PACKAGE }} git ${{ inputs.WORK_PACKAGE_URL }}${{ inputs.CURRENT_PACKAGE }}
-        COMPOSER_ROOT_VERSION=${{ inputs.COMPOSER_ROOT_VERSION }} composer require "yiisoft/${{ inputs.CURRENT_PACKAGE }}:${{ inputs.FULL_BRANCH_NAME }} as ${{ inputs.COMPOSER_ROOT_VERSION }}" --no-interaction --no-progress --optimize-autoloader --ansi
+        composer config "repositories.yiisoft/${CURRENT_PACKAGE}" git "${WORK_PACKAGE_URL}${CURRENT_PACKAGE}"
+        COMPOSER_ROOT_VERSION="${COMPOSER_ROOT_VERSION}" composer require "yiisoft/${CURRENT_PACKAGE}:${FULL_BRANCH_NAME} as ${COMPOSER_ROOT_VERSION}" --no-interaction --no-progress --optimize-autoloader --ansi
+      env:
+        COMPOSER_ROOT_VERSION: ${{ inputs.COMPOSER_ROOT_VERSION }}
+        CURRENT_PACKAGE: ${{ inputs.CURRENT_PACKAGE }}
+        FULL_BRANCH_NAME: ${{ inputs.FULL_BRANCH_NAME }}
+        WORK_PACKAGE_URL: ${{ inputs.WORK_PACKAGE_URL }}
 
     - name: Install from fork and branch not exists (push)
       if: ${{ github.event_name == 'push' && env.BRANCH_EXISTS == 0 }}
       shell: bash
       run: |
         echo "Push - Install from fork and branch not exists."
-        composer require yiisoft/${{ inputs.CURRENT_PACKAGE }}:dev-master --no-interaction --no-progress --optimize-autoloader --ansi
+        composer require "yiisoft/${CURRENT_PACKAGE}:dev-master" --no-interaction --no-progress --optimize-autoloader --ansi
+      env:
+        CURRENT_PACKAGE: ${{ inputs.CURRENT_PACKAGE }}

--- a/install-packages/action.yml
+++ b/install-packages/action.yml
@@ -25,42 +25,42 @@ runs:
 
     - if: ${{ fromJSON(inputs.packages)[0] != '' }}
       name: Install ${{ fromJSON(inputs.packages)[0] }}.
-      uses: yiisoft/actions/install-packages/install-package@ab62d6b3b0e0cff6c9724ec5a395bedb41c639a2
+      uses: yiisoft/actions/install-packages/install-package@master
       with:
         package: ${{ fromJSON(inputs.packages)[0] }}
         composer-root-version: ${{ steps.latest_release.outputs.current }}
 
     - if: ${{ fromJSON(inputs.packages)[1] != '' }}
       name: Install ${{ fromJSON(inputs.packages)[1] }}.
-      uses: yiisoft/actions/install-packages/install-package@ab62d6b3b0e0cff6c9724ec5a395bedb41c639a2
+      uses: yiisoft/actions/install-packages/install-package@master
       with:
         package: ${{ fromJSON(inputs.packages)[1] }}
         composer-root-version: ${{ steps.latest_release.outputs.current }}
 
     - if: ${{ fromJSON(inputs.packages)[2] != '' }}
       name: Install ${{ fromJSON(inputs.packages)[2] }}.
-      uses: yiisoft/actions/install-packages/install-package@ab62d6b3b0e0cff6c9724ec5a395bedb41c639a2
+      uses: yiisoft/actions/install-packages/install-package@master
       with:
         package: ${{ fromJSON(inputs.packages)[2] }}
         composer-root-version: ${{ steps.latest_release.outputs.current }}
 
     - if: ${{ fromJSON(inputs.packages)[3] != '' }}
       name: Install ${{ fromJSON(inputs.packages)[3] }}.
-      uses: yiisoft/actions/install-packages/install-package@ab62d6b3b0e0cff6c9724ec5a395bedb41c639a2
+      uses: yiisoft/actions/install-packages/install-package@master
       with:
         package: ${{ fromJSON(inputs.packages)[3] }}
         composer-root-version: ${{ steps.latest_release.outputs.current }}
 
     - if: ${{ fromJSON(inputs.packages)[4] != '' }}
       name: Install ${{ fromJSON(inputs.packages)[4] }}.
-      uses: yiisoft/actions/install-packages/install-package@ab62d6b3b0e0cff6c9724ec5a395bedb41c639a2
+      uses: yiisoft/actions/install-packages/install-package@master
       with:
         package: ${{ fromJSON(inputs.packages)[4] }}
         composer-root-version: ${{ steps.latest_release.outputs.current }}
 
     - if: ${{ fromJSON(inputs.packages)[5] != '' }}
       name: Install ${{ fromJSON(inputs.packages)[5] }}.
-      uses: yiisoft/actions/install-packages/install-package@ab62d6b3b0e0cff6c9724ec5a395bedb41c639a2
+      uses: yiisoft/actions/install-packages/install-package@master
       with:
         package: ${{ fromJSON(inputs.packages)[5] }}
         composer-root-version: ${{ steps.latest_release.outputs.current }}

--- a/install-packages/action.yml
+++ b/install-packages/action.yml
@@ -12,53 +12,55 @@ runs:
   steps:
     - name: Get the latest release tag name of yiisoft/${{ github.event.pull_request.base.repo.name || github.event.repository.name }}
       id: latest_release
-      uses: actions/github-script@v8
+      uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd
+      env:
+        CURRENT_REPOSITORY: ${{ github.event.pull_request.base.repo.name || github.event.repository.name }}
       with:
         script: |
           const currentLatestRelease = await github.rest.repos.getLatestRelease({
             owner: 'yiisoft',
-            repo: '${{ github.event.pull_request.base.repo.name || github.event.repository.name }}'
+            repo: process.env.CURRENT_REPOSITORY
           });
           core.setOutput('current', currentLatestRelease.data.tag_name);
 
     - if: ${{ fromJSON(inputs.packages)[0] != '' }}
       name: Install ${{ fromJSON(inputs.packages)[0] }}.
-      uses: yiisoft/actions/install-packages/install-package@master
+      uses: yiisoft/actions/install-packages/install-package@ab62d6b3b0e0cff6c9724ec5a395bedb41c639a2
       with:
         package: ${{ fromJSON(inputs.packages)[0] }}
         composer-root-version: ${{ steps.latest_release.outputs.current }}
 
     - if: ${{ fromJSON(inputs.packages)[1] != '' }}
       name: Install ${{ fromJSON(inputs.packages)[1] }}.
-      uses: yiisoft/actions/install-packages/install-package@master
+      uses: yiisoft/actions/install-packages/install-package@ab62d6b3b0e0cff6c9724ec5a395bedb41c639a2
       with:
         package: ${{ fromJSON(inputs.packages)[1] }}
         composer-root-version: ${{ steps.latest_release.outputs.current }}
 
     - if: ${{ fromJSON(inputs.packages)[2] != '' }}
       name: Install ${{ fromJSON(inputs.packages)[2] }}.
-      uses: yiisoft/actions/install-packages/install-package@master
+      uses: yiisoft/actions/install-packages/install-package@ab62d6b3b0e0cff6c9724ec5a395bedb41c639a2
       with:
         package: ${{ fromJSON(inputs.packages)[2] }}
         composer-root-version: ${{ steps.latest_release.outputs.current }}
 
     - if: ${{ fromJSON(inputs.packages)[3] != '' }}
       name: Install ${{ fromJSON(inputs.packages)[3] }}.
-      uses: yiisoft/actions/install-packages/install-package@master
+      uses: yiisoft/actions/install-packages/install-package@ab62d6b3b0e0cff6c9724ec5a395bedb41c639a2
       with:
         package: ${{ fromJSON(inputs.packages)[3] }}
         composer-root-version: ${{ steps.latest_release.outputs.current }}
 
     - if: ${{ fromJSON(inputs.packages)[4] != '' }}
       name: Install ${{ fromJSON(inputs.packages)[4] }}.
-      uses: yiisoft/actions/install-packages/install-package@master
+      uses: yiisoft/actions/install-packages/install-package@ab62d6b3b0e0cff6c9724ec5a395bedb41c639a2
       with:
         package: ${{ fromJSON(inputs.packages)[4] }}
         composer-root-version: ${{ steps.latest_release.outputs.current }}
 
     - if: ${{ fromJSON(inputs.packages)[5] != '' }}
       name: Install ${{ fromJSON(inputs.packages)[5] }}.
-      uses: yiisoft/actions/install-packages/install-package@master
+      uses: yiisoft/actions/install-packages/install-package@ab62d6b3b0e0cff6c9724ec5a395bedb41c639a2
       with:
         package: ${{ fromJSON(inputs.packages)[5] }}
         composer-root-version: ${{ steps.latest_release.outputs.current }}

--- a/install-packages/install-package/action.yml
+++ b/install-packages/install-package/action.yml
@@ -16,62 +16,98 @@ runs:
   steps:
     - name: Get the latest release tag names
       id: latest_release
-      uses: actions/github-script@v8
+      uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd
+      env:
+        INPUTS_PACKAGE: ${{ inputs.package }}
+        INPUTS_COMPOSER_ROOT_VERSION: ${{ inputs.composer-root-version }}
+        CURRENT_REPOSITORY: ${{ github.event.pull_request.base.repo.name || github.event.repository.name }}
       with:
         script: |
           const packageLatestRelease = await github.rest.repos.getLatestRelease({
             owner: 'yiisoft',
-            repo: '${{ inputs.package }}'
+            repo: process.env.INPUTS_PACKAGE
           });
           core.setOutput('package', packageLatestRelease.data.tag_name);
-          if ('${{ inputs.composer-root-version }}' == '') {
+          if (process.env.INPUTS_COMPOSER_ROOT_VERSION === '') {
             const currentLatestRelease = await github.rest.repos.getLatestRelease({
               owner: 'yiisoft',
-              repo: '${{ github.event.pull_request.base.repo.name || github.event.repository.name }}'
+              repo: process.env.CURRENT_REPOSITORY
             });
             core.setOutput('current', currentLatestRelease.data.tag_name);
           }
 
     - name: Set COMPOSER_ROOT_VERSION of yiisoft/${{ github.event.pull_request.base.repo.name || github.event.repository.name }}
+      id: composer_root_version
       shell: bash
       run: |
-        echo "COMPOSER_ROOT_VERSION=${{ inputs.composer-root-version || steps.latest_release.outputs.current }}" >> $GITHUB_ENV
+        value="${INPUTS_COMPOSER_ROOT_VERSION:-$STEPS_LATEST_RELEASE_OUTPUTS_CURRENT}"
+        echo "value=$value" >> "$GITHUB_OUTPUT"
+      env:
+        INPUTS_COMPOSER_ROOT_VERSION: ${{ inputs.composer-root-version }}
+        STEPS_LATEST_RELEASE_OUTPUTS_CURRENT: ${{ steps.latest_release.outputs.current }}
 
     - if: ${{ github.event_name == 'pull_request' || github.event_name == 'pull_request_target' }}
       name: Set environment variable for work package url (pull request).
+      id: work_package
       shell: bash
       run: |
-        work_package_url="https://github.com/${{ github.event.pull_request.head.repo.owner.login }}/"
-        echo "WORK_PACKAGE_URL=${work_package_url}" >> $GITHUB_ENV
-        echo "FULL_BRANCH_NAME=dev-${{ github.head_ref }}" >> $GITHUB_ENV
-        if [[ "${{ github.event.pull_request.head.repo.name }}" != "${{ github.event.pull_request.base.repo.name }}" ]];
+        work_package_url="https://github.com/${GITHUB_EVENT_PULL_REQUEST_HEAD_REPO_OWNER_LOGIN}/"
+        full_branch_name="dev-${GITHUB_HEAD_REF}"
+        fork_prefix=""
+        if [[ "${GITHUB_EVENT_PULL_REQUEST_HEAD_REPO_NAME}" != "${GITHUB_EVENT_PULL_REQUEST_BASE_REPO_NAME}" ]];
         then
-            fork_name="${{ github.event.pull_request.head.repo.name }}"
-            repo_name="${{ github.event.pull_request.base.repo.name }}"
+            fork_name="${GITHUB_EVENT_PULL_REQUEST_HEAD_REPO_NAME}"
+            repo_name="${GITHUB_EVENT_PULL_REQUEST_BASE_REPO_NAME}"
             fork_prefix=${fork_name%${repo_name}}
-            echo "FORK_PREFIX=${fork_prefix}" >> $GITHUB_ENV
         fi
-        if git ls-remote --heads --exit-code ${work_package_url}${fork_prefix}${{ inputs.package }} "${{ github.head_ref }}";
-        then echo "BRANCH_EXISTS=1" >> $GITHUB_ENV; else echo "BRANCH_EXISTS=0" >> $GITHUB_ENV; fi
+        if git ls-remote --heads --exit-code ${work_package_url}${fork_prefix}${INPUTS_PACKAGE} "${GITHUB_HEAD_REF}";
+        then branch_exists=1; else branch_exists=0; fi
+        {
+          echo "work_package_url=$work_package_url"
+          echo "full_branch_name=$full_branch_name"
+          echo "fork_prefix=$fork_prefix"
+          echo "branch_exists=$branch_exists"
+        } >> "$GITHUB_OUTPUT"
+      env:
+        GITHUB_EVENT_PULL_REQUEST_HEAD_REPO_OWNER_LOGIN: ${{ github.event.pull_request.head.repo.owner.login }}
+        GITHUB_EVENT_PULL_REQUEST_HEAD_REPO_NAME: ${{ github.event.pull_request.head.repo.name }}
+        GITHUB_EVENT_PULL_REQUEST_BASE_REPO_NAME: ${{ github.event.pull_request.base.repo.name }}
+        INPUTS_PACKAGE: ${{ inputs.package }}
 
-    - if: ${{ env.BRANCH_EXISTS == 1 && github.event.pull_request.head.repo.fork }}
+    - if: ${{ steps.work_package.outputs.branch_exists == '1' && github.event.pull_request.head.repo.fork }}
       name: Install from fork and branch exists.
       shell: bash
       run: |
         echo "Pull Request - Install from fork and branch exists."
-        composer config repositories.yiisoft/${{ inputs.package }} git ${{ env.WORK_PACKAGE_URL }}${{ env.FORK_PREFIX }}${{ inputs.package }}
-        composer require "yiisoft/${{ inputs.package }}:${{ env.FULL_BRANCH_NAME }} as ${{ steps.latest_release.outputs.package }}" --no-interaction --no-progress --optimize-autoloader --ansi
+        composer config repositories.yiisoft/${INPUTS_PACKAGE} git ${WORK_PACKAGE_URL}${FORK_PREFIX}${INPUTS_PACKAGE}
+        composer require "yiisoft/${INPUTS_PACKAGE}:${FULL_BRANCH_NAME} as ${STEPS_LATEST_RELEASE_OUTPUTS_PACKAGE}" --no-interaction --no-progress --optimize-autoloader --ansi
+      env:
+        INPUTS_PACKAGE: ${{ inputs.package }}
+        STEPS_LATEST_RELEASE_OUTPUTS_PACKAGE: ${{ steps.latest_release.outputs.package }}
+        COMPOSER_ROOT_VERSION: ${{ steps.composer_root_version.outputs.value }}
+        WORK_PACKAGE_URL: ${{ steps.work_package.outputs.work_package_url }}
+        FORK_PREFIX: ${{ steps.work_package.outputs.fork_prefix }}
+        FULL_BRANCH_NAME: ${{ steps.work_package.outputs.full_branch_name }}
 
-    - if: ${{ env.BRANCH_EXISTS == 1 && !github.event.pull_request.head.repo.fork }}
+    - if: ${{ steps.work_package.outputs.branch_exists == '1' && !github.event.pull_request.head.repo.fork }}
       name: Install from branch and branch exists.
       shell: bash
       run: |
         echo "Pull Request - Install from branch and branch exists."
-        composer require "yiisoft/${{ inputs.package }}:${{ env.FULL_BRANCH_NAME }} as ${{ steps.latest_release.outputs.package }}" --no-interaction --no-progress --optimize-autoloader --ansi
+        composer require "yiisoft/${INPUTS_PACKAGE}:${FULL_BRANCH_NAME} as ${STEPS_LATEST_RELEASE_OUTPUTS_PACKAGE}" --no-interaction --no-progress --optimize-autoloader --ansi
+      env:
+        INPUTS_PACKAGE: ${{ inputs.package }}
+        STEPS_LATEST_RELEASE_OUTPUTS_PACKAGE: ${{ steps.latest_release.outputs.package }}
+        COMPOSER_ROOT_VERSION: ${{ steps.composer_root_version.outputs.value }}
+        FULL_BRANCH_NAME: ${{ steps.work_package.outputs.full_branch_name }}
 
-    - if: ${{ env.BRANCH_EXISTS == 0 }}
+    - if: ${{ steps.work_package.outputs.branch_exists == '0' }}
       name: Install from master and branch not exists.
       shell: bash
       run: |
         echo "Pull Request - Install from master and branch not exists."
-        composer require "yiisoft/${{ inputs.package }}:dev-master as ${{ steps.latest_release.outputs.package }}" --no-interaction --no-progress --optimize-autoloader --ansi
+        composer require "yiisoft/${INPUTS_PACKAGE}:dev-master as ${STEPS_LATEST_RELEASE_OUTPUTS_PACKAGE}" --no-interaction --no-progress --optimize-autoloader --ansi
+      env:
+        INPUTS_PACKAGE: ${{ inputs.package }}
+        STEPS_LATEST_RELEASE_OUTPUTS_PACKAGE: ${{ steps.latest_release.outputs.package }}
+        COMPOSER_ROOT_VERSION: ${{ steps.composer_root_version.outputs.value }}

--- a/install-packages/install-package/action.yml
+++ b/install-packages/install-package/action.yml
@@ -38,13 +38,15 @@ runs:
 
     - name: Set COMPOSER_ROOT_VERSION of yiisoft/${{ github.event.pull_request.base.repo.name || github.event.repository.name }}
       id: composer_root_version
-      shell: bash
-      run: |
-        value="${INPUTS_COMPOSER_ROOT_VERSION:-$STEPS_LATEST_RELEASE_OUTPUTS_CURRENT}"
-        echo "value=$value" >> "$GITHUB_OUTPUT"
+      uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd
       env:
         INPUTS_COMPOSER_ROOT_VERSION: ${{ inputs.composer-root-version }}
         STEPS_LATEST_RELEASE_OUTPUTS_CURRENT: ${{ steps.latest_release.outputs.current }}
+      with:
+        script: |
+          const value = process.env.INPUTS_COMPOSER_ROOT_VERSION || process.env.STEPS_LATEST_RELEASE_OUTPUTS_CURRENT;
+          core.setOutput('value', value);
+          core.exportVariable('COMPOSER_ROOT_VERSION', value);
 
     - if: ${{ github.event_name == 'pull_request' || github.event_name == 'pull_request_target' }}
       name: Set environment variable for work package url (pull request).


### PR DESCRIPTION
## Summary
- Pin reusable workflow and composite action dependencies
- Disable checkout credential persistence and configure explicit credentials for commit-pushing workflows
- Avoid direct template interpolation in shell and github-script bodies
- Replace composite-action environment propagation with step outputs where zizmor flagged it

## Validation
- zizmor --no-progress --no-exit-codes .github/workflows install-packages
- git diff --check