### PR TITLE
Fix #86: Add Codecov fail CI option

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -57,6 +57,11 @@ on:
         default: false
         required: false
         type: boolean
+      codecovFailCiIfError:
+        description: Specify whether Codecov upload errors should fail the workflow.
+        default: false
+        required: false
+        type: boolean
     secrets:
       CODECOV_TOKEN:
         description: Codecov upload token
@@ -162,3 +167,4 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN || secrets.codecovToken }}
           files: ./coverage.xml
           verbose: ${{ inputs.codecovVerbose }}
+          fail_ci_if_error: ${{ inputs.codecovFailCiIfError }}

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -59,7 +59,7 @@ on:
         type: boolean
       codecovFailCiIfError:
         description: Specify whether Codecov upload errors should fail the workflow.
-        default: false
+        default: true
         required: false
         type: boolean
     secrets:

--- a/docs/php-unit.md
+++ b/docs/php-unit.md
@@ -29,7 +29,7 @@ jobs:
     uses: yiisoft/actions/.github/workflows/phpunit.yml@master
     with:
       # coverage: pcov / coverage: xdebug / coverage: xdebug2 / coverage: none 
-      # codecovFailCiIfError: true
+      # codecovFailCiIfError: false
       # extensions: pdo, pdo_pgsql
       # ini-values: date.timezone='UTC'      
       os: >-

--- a/docs/php-unit.md
+++ b/docs/php-unit.md
@@ -29,6 +29,7 @@ jobs:
     uses: yiisoft/actions/.github/workflows/phpunit.yml@master
     with:
       # coverage: pcov / coverage: xdebug / coverage: xdebug2 / coverage: none 
+      # codecovFailCiIfError: true
       # extensions: pdo, pdo_pgsql
       # ini-values: date.timezone='UTC'      
       os: >-


### PR DESCRIPTION
| Q             | A |
|---------------|---|
| Bug fix?      | no |
| New feature?  | yes |
| Issues        | Fix #86 |

Adds a `codecovFailCiIfError` input to the PHPUnit reusable workflow and passes it to `codecov/codecov-action` as `fail_ci_if_error`.

The default is `false` to preserve existing behavior.
