### PR TITLE
Fix #52: Skip Rector auto-commit for fork pull requests

### DIFF
--- a/.github/workflows/rector.yml
+++ b/.github/workflows/rector.yml
@@ -115,11 +115,13 @@ jobs:
       - run: vendor/bin/rector process --ansi --output-format=github
 
       - name: Configure Git credentials
+        if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork }}
         env:
           GH_TOKEN: ${{ secrets.token || github.token }}
         run: git config --global credential.helper '!f() { echo username=x-access-token; echo password=$GH_TOKEN; }; f'
 
       - name: Commit changes
+        if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork }}
         env:
           GH_TOKEN: ${{ secrets.token || github.token }}
         run: |

--- a/.github/workflows/rector.yml
+++ b/.github/workflows/rector.yml
@@ -62,7 +62,7 @@ jobs:
         with:
           token: ${{ secrets.token || github.token }}
           ref: ${{ github.head_ref }}
-          repository: ${{ inputs.repository }}
+          repository: ${{ inputs.repository || github.event.pull_request.head.repo.full_name || github.repository }}
           persist-credentials: false
 
       - name: Install PHP with extensions

--- a/docs/rector.md
+++ b/docs/rector.md
@@ -58,3 +58,7 @@ jobs:
     secrets:
       token: ${{ secrets.REPO_GITHUB_TOKEN }}
 ```
+
+For pull requests from forks, the workflow runs Rector but does not commit changes
+back to the fork branch because GitHub does not expose write credentials to these
+runs.

--- a/docs/rector.md
+++ b/docs/rector.md
@@ -59,6 +59,6 @@ jobs:
       token: ${{ secrets.REPO_GITHUB_TOKEN }}
 ```
 
-For pull requests from forks, the workflow runs Rector but does not commit changes
-back to the fork branch because GitHub does not expose write credentials to these
-runs.
+For pull requests from forks, the workflow checks out the fork branch and runs
+Rector, but does not commit changes back to the fork branch because GitHub does
+not expose write credentials to these runs.


### PR DESCRIPTION
| Q             | A |
|---------------|---|
| Bug fix?      | yes |
| New feature?  | no |
| Issues        | Fix #52 |

Skips Rector credential setup and auto-commit/push on pull requests from forks.

The workflow still runs Rector, but it no longer tries to push changes when GitHub does not expose write credentials for the fork PR run.
