### PR TITLE
Fix #12: Adjust shared Rector config

### DIFF
--- a/config/rector.php
+++ b/config/rector.php
@@ -33,12 +33,21 @@ return static function (\Rector\Config\RectorConfig $rectorConfig): void {
         ],
     );
 
+    $rectorConfig->rules(
+        [
+            \Rector\DeadCode\Rector\ClassMethod\RemoveUselessParamTagRector::class,
+            \Rector\DeadCode\Rector\ClassMethod\RemoveUselessReturnTagRector::class,
+            \Rector\Transform\Rector\String_\StringToClassConstantRector::class,
+        ],
+    );
+
     $rectorConfig->skip(
         [
             \Rector\CodingStyle\Rector\Property\SplitGroupedPropertiesRector::class,
             \Rector\CodingStyle\Rector\Stmt\NewlineAfterStatementRector::class,
             \Rector\Php73\Rector\String_\SensitiveHereNowDocRector::class,
             \Rector\Php74\Rector\Closure\ClosureToArrowFunctionRector::class,
+            \Rector\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector::class,
             \Rector\Php81\Rector\Property\ReadOnlyPropertyRector::class,
         ],
     );


### PR DESCRIPTION
| Q             | A |
|---------------|---|
| Bug fix?      | no |
| New feature?  | yes |
| Issues        | Fix #12 |

Updates the shared Rector config to:

- remove useless `@param` and `@return` tags,
- convert class-name strings to `::class`,
- skip constructor property promotion to avoid the reported formatting/type issues.

`NonVariableToVariableOnFunctionCallRector` is not added to the skip list because it is not present in current Rector.
